### PR TITLE
feat: Reserved @session script variable

### DIFF
--- a/Vidyano.Script.Tool/ConsoleReporter.cs
+++ b/Vidyano.Script.Tool/ConsoleReporter.cs
@@ -108,14 +108,19 @@ public static class ConsoleReporter
     private static void RenderSnapshot(Snapshot snap)
     {
         if (snap.Po is { } po)
-        {
-            var t = new Table().Border(TableBorder.Rounded).Title($"[bold]{Markup.Escape(po.Type)}[/] / {Markup.Escape(po.ObjectId ?? "<new>")}");
-            t.AddColumn("Attribute"); t.AddColumn("Value"); t.AddColumn("R/O"); t.AddColumn("Req'd"); t.AddColumn("Vis.");
-            foreach (var a in po.Attributes)
-                t.AddRow(Markup.Escape(a.Name), Markup.Escape(a.DisplayValue ?? a.Value ?? ""), a.IsReadOnly ? "✓" : "", a.IsRequired ? "✓" : "", a.IsVisible ? "" : "hidden");
-            AnsiConsole.Write(t);
-        }
+            RenderPoTable(po, $"[bold]{Markup.Escape(po.Type)}[/] / {Markup.Escape(po.ObjectId ?? "<new>")}");
+        if (snap.SessionPo is { } sess)
+            RenderPoTable(sess, $"[bold]@session[/] [grey]({Markup.Escape(sess.Type)})[/]");
         if (snap.Query is { } q)
             AnsiConsole.MarkupLine($"    [grey]Query[/] {Markup.Escape(q.Name)} — {q.TotalItems} item(s)");
+    }
+
+    private static void RenderPoTable(PoSnapshot po, string title)
+    {
+        var t = new Table().Border(TableBorder.Rounded).Title(title);
+        t.AddColumn("Attribute"); t.AddColumn("Value"); t.AddColumn("R/O"); t.AddColumn("Req'd"); t.AddColumn("Vis.");
+        foreach (var a in po.Attributes)
+            t.AddRow(Markup.Escape(a.Name), Markup.Escape(a.DisplayValue ?? a.Value ?? ""), a.IsReadOnly ? "✓" : "", a.IsRequired ? "✓" : "", a.IsVisible ? "" : "hidden");
+        AnsiConsole.Write(t);
     }
 }

--- a/Vidyano.Script.Tool/README.md
+++ b/Vidyano.Script.Tool/README.md
@@ -98,6 +98,10 @@ EXPECT TotalItems = 6
 
 EXPECT supports nav-stack state, notification state, the `ClientOperation` queue, and arbitrary attributes on the current PO. CONTAINS / IS NULL / IS NOT NULL / NOT CONTAINS make negative assertions readable.
 
+### Reserved `@session`
+
+`Client.Session` (the built-in Vidyano session PO) is reachable as `@session.<attr>` — write with `SET @session.X = …` (auto-enters edit on the Session PO), read with `SET Y = @session.X` or `EXPECT @session.X = …`, interpolate with `{{@session.X}}`. The names `session`, `user`, and `application` are reserved by the engine — `@session = …` is a parse error.
+
 ## CI / agent use
 
 `--json` emits NDJSON suitable for piping into a log collector. Each verb produces one event with its result, timing, and any guard violation. Pair with an exit-code check:

--- a/Vidyano.Script.Tool/VerbReference.cs
+++ b/Vidyano.Script.Tool/VerbReference.cs
@@ -18,6 +18,7 @@ public static class VerbReference
 
         t.AddRow("@var = value",         "@app = http://localhost:5000",        "Define a script variable. Reference with {{var}}.");
         t.AddRow("@mode = ...",          "@mode = audit",                       "navigation (default) | audit | direct. Set before any verb.");
+        t.AddRow("@session.<attr>",      "SET @session.CurrentYear = 2026",     "Read/write Client.Session. Also: EXPECT @session.X = … and {{@session.X}}.");
         t.AddRow("SIGN-IN",              "SIGN-IN admin / admin",               "Or: SIGN-IN @admin = user / pwd  (named session).");
         t.AddRow("USE",                  "USE @admin",                          "Switch to a named session (multi-session not yet implemented).");
         t.AddRow("OPEN PersistentObject","OPEN PersistentObject \"Customer\" \"42\" AS @c","Opens a PO directly. In navigation mode requires reachability.");

--- a/Vidyano.Script.Tool/samples/session-scope.visc
+++ b/Vidyano.Script.Tool/samples/session-scope.visc
@@ -1,0 +1,44 @@
+### Reserved @session variable — read, write, interpolate, and the reserved-name grammar.
+#
+# `@session` binds to Client.Session, the built-in Vidyano session PO that auto-roundtrips
+# with every request. SET on @session lasts for the rest of the script without leaving the
+# current nav frame.
+#
+# NOTE: the local Raven sample at https://localhost:44353/ may not expose a Session PO.
+# When it doesn't, the SET/EXPECT @session.* lines below produce
+#   state-no-session: "No Session PO on this app — `@session` is unbound."
+# Uncomment the WRITE/READ blocks once the sample app wires up a Session.
+
+@app = "https://localhost:44353/"
+SIGN-IN admin / anything
+
+### Reserved-name parse error — lint-only demo.
+# Each of these would emit "`@session` is reserved — bound to Client.Session by the engine."
+# at parse time. They are commented so the executable portion lints clean.
+# @session = 42
+# @user = "alice"
+# @application = "demo"
+#
+# @session in value position without a `.attr` is a parse error:
+#   "`@session` is a PO reference, not a value — use `@session.<attr>`."
+# SET Year = @session
+#
+# Unknown scope under @… in SET position:
+#   parse-unexpected-token: "Unknown variable scope '@notarealscope'."
+# SET @notarealscope.X = 1
+
+### WRITE / READ / EXPECT / INTERPOLATE (blocked until the sample exposes a Session).
+# SET @session.CurrentYear = 2026
+# EXPECT @session.CurrentYear = 2026
+#
+# OPEN PersistentObject "SomeType" "some-id"
+# EDIT
+# SET Year = @session.CurrentYear
+# EXPECT Year = 2026
+#
+# EXPECT @session.Personen_Patient IS NULL
+# EXPECT @session.Personen_Patient CONTAINS "Reymen"
+# EXPECT Attribute @session.Personen_Patient IS NOT REQUIRED
+#
+# OPEN Query Patients
+# SEARCH "Id:{{@session.Personen_Patient}}"

--- a/Vidyano.Script/Diagnostics/ErrorKind.cs
+++ b/Vidyano.Script/Diagnostics/ErrorKind.cs
@@ -51,6 +51,8 @@ public static class ErrorKind
     public const string StateNotSignedIn         = "state-not-signed-in";
     public const string StateNoCurrentPo         = "state-no-current-po";
     public const string StateNoCurrentQuery      = "state-no-current-query";
+    public const string StateNoSession           = "state-no-session";
+    public const string StateScopeNotImplemented = "state-scope-not-implemented";
     public const string StateHandleStale         = "state-handle-stale";
 
     // Assertions

--- a/Vidyano.Script/Parsing/Ast.cs
+++ b/Vidyano.Script/Parsing/Ast.cs
@@ -68,7 +68,9 @@ public sealed record RefreshStmt(string? Handle, SourceLocation Location) : Stat
 /// <c>SET Name = LOOKUP "filter"</c> forces a lookup search; <c>SET Name = ID "guid"</c> sets the
 /// raw <c>SelectedReferenceValue</c> without going through Options or Lookup.
 /// </summary>
-public sealed record SetStmt(string? Handle, string Attribute, Expression Value, ReferenceHintKind? Hint, SourceLocation Location) : Statement(Location);
+/// <param name="Scope">Reserved variable scope for the target PO (<c>"session"</c> for
+/// <c>@session.X</c>); <c>null</c> means the top of the navigation stack.</param>
+public sealed record SetStmt(string? Handle, string Attribute, Expression Value, ReferenceHintKind? Hint, SourceLocation Location, string? Scope = null) : Statement(Location);
 
 /// <summary><c>ACTION Approve [(Param=Value, ...)]</c>.</summary>
 public sealed record ActionStmt(string? Handle, string ActionName, IReadOnlyDictionary<string, Expression>? Parameters, SourceLocation Location) : Statement(Location);
@@ -127,8 +129,10 @@ public enum ExpectSubjectKind
 }
 
 /// <summary>A parsed <c>EXPECT</c> subject. <see cref="Name"/> is meaningful for Attribute/Action/AttributeFlag;
-/// <see cref="Lhs"/> is set for <see cref="ExpectSubjectKind.Expression"/> (interpolation-as-subject).</summary>
-public sealed record ExpectSubject(ExpectSubjectKind Kind, string? Name, AttributeFlagKind Flag, SourceLocation Location, Expression? Lhs = null);
+/// <see cref="Lhs"/> is set for <see cref="ExpectSubjectKind.Expression"/> (interpolation-as-subject).
+/// <see cref="Scope"/> is the reserved variable scope (<c>"session"</c>) when the subject is
+/// <c>@session.X</c>; <c>null</c> means the top of the navigation stack.</summary>
+public sealed record ExpectSubject(ExpectSubjectKind Kind, string? Name, AttributeFlagKind Flag, SourceLocation Location, Expression? Lhs = null, string? Scope = null);
 
 /// <summary>Which boolean attribute property an <c>EXPECT Attribute X IS ...</c> targets.</summary>
 public enum AttributeFlagKind { None, Visible, ReadOnly, Required }
@@ -150,3 +154,8 @@ public sealed record IdentifierExpr(string Name, SourceLocation Location) : Expr
 
 /// <summary><c>{{...}}</c> — a variable interpolation. <see cref="Inner"/> is the raw text between braces.</summary>
 public sealed record InterpExpr(string Inner, SourceLocation Location) : Expression(Location);
+
+/// <summary><c>@scope.AttributeName</c> in value position — read an attribute from a reserved
+/// scoped PO (<c>@session</c>). The interpreter dispatches to
+/// <see cref="VidyanoSession.GetScopedAttributeValue"/>.</summary>
+public sealed record VariableAttributeExpr(string Scope, string AttributeName, SourceLocation Location) : Expression(Location);

--- a/Vidyano.Script/Parsing/Parser.cs
+++ b/Vidyano.Script/Parsing/Parser.cs
@@ -30,6 +30,15 @@ public sealed class Parser
         "PersistentObject", "Query", "MenuItem", "Detail",
     };
 
+    /// <summary>Reserved <c>@name</c> identifiers that the engine binds to fixed scoped PersistentObjects
+    /// (<c>session</c> → <c>Client.Session</c>; <c>user</c> / <c>application</c> reserved for future use).
+    /// Assigning to any of these is a parse error — they're not script variables, so allowing
+    /// <c>@session = …</c> would silently shadow the binding.</summary>
+    private static readonly HashSet<string> ReservedScopes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "session", "user", "application",
+    };
+
     public Parser(IReadOnlyList<Token> tokens, IEnumerable<Diagnostic>? lexerDiagnostics = null)
     {
         _tokens = tokens;
@@ -152,6 +161,17 @@ public sealed class Parser
             return null;
         }
 
+        if (ReservedScopes.Contains(at.Lexeme))
+        {
+            // Capitalize for the diagnostic — "Client.Session" reads better than "Client.session".
+            var pascal = char.ToUpperInvariant(at.Lexeme[0]) + at.Lexeme.Substring(1).ToLowerInvariant();
+            Error(ErrorKind.ParseUnexpectedToken,
+                $"`@{at.Lexeme}` is reserved — bound to Client.{pascal} by the engine.",
+                at.Location,
+                hint: $"Read with `@{at.Lexeme}.<attr>`; write with `SET @{at.Lexeme}.<attr> = …`. Pick a different name for a script variable.");
+            return null;
+        }
+
         if (!Match(TokenKind.Equals, out _))
         {
             Error(ErrorKind.ParseExpected,
@@ -196,7 +216,8 @@ public sealed class Parser
         string? sessionName = null;
         if (Peek().Kind == TokenKind.At)
         {
-            sessionName = Advance().Lexeme;
+            sessionName = ConsumeHandleName("SIGN-IN");
+            if (sessionName is null) return null;
             if (!Match(TokenKind.Equals, out _))
             {
                 Error(ErrorKind.ParseExpected, $"Expected '=' after SIGN-IN @{sessionName}.", Peek().Location);
@@ -231,7 +252,10 @@ public sealed class Parser
     {
         string? sessionName = null;
         if (Peek().Kind == TokenKind.At)
-            sessionName = Advance().Lexeme;
+        {
+            sessionName = ConsumeHandleName("SIGN-OUT");
+            if (sessionName is null) return null;
+        }
         return new SignOutStmt(sessionName, loc);
     }
 
@@ -245,7 +269,8 @@ public sealed class Parser
                 hint: "USE @admin");
             return null;
         }
-        var name = Advance().Lexeme;
+        var name = ConsumeHandleName("USE");
+        if (name is null) return null;
         return new UseSessionStmt(name, loc);
     }
 
@@ -326,15 +351,19 @@ public sealed class Parser
 
     private Statement? ParseSet(SourceLocation loc)
     {
-        if (Peek().Kind != TokenKind.Identifier)
+        // Optional reserved-scope prefix: SET @session.Attr = …
+        string? scope = null;
+        if (Peek().Kind == TokenKind.At)
         {
-            Error(ErrorKind.ParseExpected, "SET needs an attribute name.", Peek().Location, hint: "SET Name = \"value\"");
-            return null;
+            scope = TryConsumeScopePrefix();
+            if (scope == null) return null;
         }
-        var nameTok = Advance();
+
+        var attrName = ParseDottedAttributeName();
+        if (attrName == null) return null;
         if (!Match(TokenKind.Equals, out _))
         {
-            Error(ErrorKind.ParseExpected, $"Expected '=' after SET {nameTok.Lexeme}.", Peek().Location);
+            Error(ErrorKind.ParseExpected, $"Expected '=' after SET {attrName}.", Peek().Location);
             return null;
         }
 
@@ -348,7 +377,28 @@ public sealed class Parser
 
         var value = ParseValueExpression();
         if (value == null) return null;
-        return new SetStmt(null, nameTok.Lexeme, value, hint, loc);
+        return new SetStmt(null, attrName, value, hint, loc, scope);
+    }
+
+    /// <summary>Reads an attribute name token sequence of the form <c>Identifier (. Identifier)*</c>
+    /// and returns the dotted join. Vidyano auto-populates dotted attributes (e.g.
+    /// <c>Customer.Name</c> from a <c>Customer</c> reference), so the grammar must accept them
+    /// anywhere a single attribute identifier is expected. Returns null after emitting a diagnostic
+    /// when the leading token isn't an identifier.</summary>
+    private string? ParseDottedAttributeName()
+    {
+        if (Peek().Kind != TokenKind.Identifier)
+        {
+            Error(ErrorKind.ParseExpected, "Expected an attribute name.", Peek().Location);
+            return null;
+        }
+        var sb = new System.Text.StringBuilder(Advance().Lexeme);
+        while (Peek().Kind == TokenKind.Dot && _pos + 1 < _tokens.Count && _tokens[_pos + 1].Kind == TokenKind.Identifier)
+        {
+            Advance(); // '.'
+            sb.Append('.').Append(Advance().Lexeme);
+        }
+        return sb.ToString();
     }
 
     private Statement? ParseAction(SourceLocation loc)
@@ -491,6 +541,16 @@ public sealed class Parser
             return new ExpectSubject(ExpectSubjectKind.Expression, null, AttributeFlagKind.None, tok.Location, new InterpExpr(tok.Lexeme, tok.Location));
         }
 
+        // EXPECT @session.Attr ... — scoped bare-attribute subject.
+        if (tok.Kind == TokenKind.At)
+        {
+            var scope = TryConsumeScopePrefix();
+            if (scope == null) return null;
+            var attrName = ParseDottedAttributeName();
+            if (attrName == null) return null;
+            return new ExpectSubject(ExpectSubjectKind.Attribute, attrName, AttributeFlagKind.None, tok.Location, Scope: scope);
+        }
+
         if (tok.Kind != TokenKind.Identifier)
         {
             Error(ErrorKind.ParseExpected, "EXPECT needs a subject (attribute name, IsDirty, Notification, Action, …).", tok.Location);
@@ -558,20 +618,27 @@ public sealed class Parser
         if (string.Equals(tok.Lexeme, "Attribute", StringComparison.OrdinalIgnoreCase))
         {
             Advance();
+            string? scope = null;
+            if (Peek().Kind == TokenKind.At)
+            {
+                scope = TryConsumeScopePrefix();
+                if (scope == null) return null;
+            }
             if (Peek().Kind != TokenKind.Identifier)
             {
                 Error(ErrorKind.ParseExpected, "Expected an attribute name after 'Attribute'.", Peek().Location);
                 return null;
             }
-            var nameTok = Advance();
+            var attrName = ParseDottedAttributeName();
+            if (attrName == null) return null;
             // EXPECT Attribute X LABEL = "..."
             if (Peek().Kind == TokenKind.Identifier &&
                 string.Equals(Peek().Lexeme, "LABEL", StringComparison.OrdinalIgnoreCase))
             {
                 Advance();
-                return new ExpectSubject(ExpectSubjectKind.AttributeLabel, nameTok.Lexeme, AttributeFlagKind.None, tok.Location);
+                return new ExpectSubject(ExpectSubjectKind.AttributeLabel, attrName, AttributeFlagKind.None, tok.Location, Scope: scope);
             }
-            return new ExpectSubject(ExpectSubjectKind.AttributeFlag, nameTok.Lexeme, AttributeFlagKind.None, tok.Location);
+            return new ExpectSubject(ExpectSubjectKind.AttributeFlag, attrName, AttributeFlagKind.None, tok.Location, Scope: scope);
         }
 
         if (string.Equals(tok.Lexeme, "Query", StringComparison.OrdinalIgnoreCase))
@@ -648,9 +715,42 @@ public sealed class Parser
             return null;
         }
 
-        // Bare identifier — treat as attribute on the current PO.
-        Advance();
-        return new ExpectSubject(ExpectSubjectKind.Attribute, tok.Lexeme, AttributeFlagKind.None, tok.Location);
+        // Bare identifier — treat as attribute on the current PO (dotted names allowed).
+        var bareName = ParseDottedAttributeName();
+        if (bareName == null) return null;
+        return new ExpectSubject(ExpectSubjectKind.Attribute, bareName, AttributeFlagKind.None, tok.Location);
+    }
+
+    /// <summary>Consumes an <c>@scope</c> prefix used in SET targets, EXPECT subjects, and value
+    /// expressions. Emits a diagnostic and returns null when the name isn't a reserved scope. The
+    /// caller is responsible for consuming the trailing <c>.</c> (because some sites need to peek
+    /// further before deciding to require the dot).</summary>
+    private string? TryConsumeScopePrefix()
+    {
+        var atTok = Advance();
+        if (atTok.Lexeme.Length == 0)
+        {
+            Error(ErrorKind.ParseExpected, "Expected a scope name after '@'.", atTok.Location);
+            return null;
+        }
+        if (!ReservedScopes.Contains(atTok.Lexeme))
+        {
+            Error(ErrorKind.ParseUnexpectedToken,
+                $"Unknown variable scope '@{atTok.Lexeme}'.",
+                atTok.Location,
+                hint: Suggester.Hint(atTok.Lexeme, ReservedScopes)
+                      ?? "Valid scopes: @session. (@user and @application are reserved but not yet implemented.)");
+            return null;
+        }
+        if (!Match(TokenKind.Dot, out _))
+        {
+            Error(ErrorKind.ParseExpected,
+                $"Expected '.<attribute>' after @{atTok.Lexeme}.",
+                Peek().Location,
+                hint: $"`@{atTok.Lexeme}` is a PO reference, not a value — use `@{atTok.Lexeme}.<attr>`.");
+            return null;
+        }
+        return atTok.Lexeme;
     }
 
     private static AttributeFlagKind ToFlag(string lexeme) =>
@@ -724,6 +824,14 @@ public sealed class Parser
                 // An identifier as a value is legal for menu segments, bare flags, etc.
                 Advance();
                 return new IdentifierExpr(tok.Lexeme, tok.Location);
+            case TokenKind.At:
+                {
+                    var scope = TryConsumeScopePrefix();
+                    if (scope == null) return null;
+                    var attr = ParseDottedAttributeName();
+                    if (attr == null) return null;
+                    return new VariableAttributeExpr(scope, attr, tok.Location);
+                }
         }
         Error(ErrorKind.ParseExpected, $"Expected a value but got {Describe(tok)}.", tok.Location,
             hint: "Values can be \"strings\", numbers, true/false/null, {{interpolations}}, or bare identifiers.");
@@ -759,8 +867,28 @@ public sealed class Parser
             Error(ErrorKind.ParseExpected, "AS needs a @handle.", Peek().Location, hint: "OPEN Query Customers AS @customers");
             return null;
         }
-        return Advance().Lexeme;
+        return ConsumeHandleName("AS");
     }
+
+    /// <summary>Consumes an <c>@handle</c> token after a verb that binds a named session
+    /// (SIGN-IN/SIGN-OUT/USE) or attaches a handle via AS. Rejects names that collide with
+    /// reserved scopes so users can't shadow the <c>@session</c> binding with a same-named handle.</summary>
+    private string? ConsumeHandleName(string verb)
+    {
+        var tok = Advance();
+        if (ReservedScopes.Contains(tok.Lexeme))
+        {
+            Error(ErrorKind.ParseUnexpectedToken,
+                $"'@{tok.Lexeme}' is reserved and can't be used as a {verb} handle.",
+                tok.Location,
+                hint: $"'@{tok.Lexeme}' is bound to Client.{ToTitle(tok.Lexeme)} by the engine. Pick a different handle name.");
+            return null;
+        }
+        return tok.Lexeme;
+    }
+
+    private static string ToTitle(string s) =>
+        s.Length == 0 ? s : char.ToUpperInvariant(s[0]) + s.Substring(1).ToLowerInvariant();
 
     private void SkipNewlines()
     {

--- a/Vidyano.Script/README.md
+++ b/Vidyano.Script/README.md
@@ -53,6 +53,18 @@ A `.visc` script is a sequence of **verbs** that drive a Vidyano session, with *
 - `SET <attribute> = <value>` — change an attribute (incl. reference SET semantics).
 - `EXECUTE <action>` — invoke an action by name.
 
+### Reserved `@session` variable
+
+`Client.Session` is reachable as `@session.<attr>` in any position — SET target, value, `EXPECT`, `{{…}}` interpolation — without leaving the current nav frame:
+
+```visc
+SET @session.Patient = LOOKUP "Naam:Smith"
+SET Year = @session.CurrentYear
+EXPECT @session.Patient CONTAINS "Smith"
+```
+
+The names `session`, `user`, `application` are reserved; `@session = …` is a parse error. `@user` / `@application` parse but produce a runtime diagnostic until wired up.
+
 EXPECT supports nav-stack state (`NavStack.Depth`, `NavStack.Top.Kind`, `NavStack.Top.Name`, `NavStack.Top.IsDialog`), query state (`TotalItems`, `IsInEdit`), notification state, and the `ClientOperation` queue:
 
 ```visc

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -182,7 +182,9 @@ public sealed class Interpreter
         var v = EvaluateExpression(s.Value);
         if (!v.Ok) return Fail(s, v.Error!);
         ReferenceHint? hint = s.Hint is null ? null : new ReferenceHint(s.Hint.Value, AsString(v.Value));
-        var res = _session.SetAttribute(s.Attribute, v.Value, s.Location, hint);
+        var res = s.Scope is null
+            ? _session.SetAttribute(s.Attribute, v.Value, s.Location, hint)
+            : _session.SetScopedAttribute(s.Scope, s.Attribute, v.Value, hint, s.Location);
         return Wrap(s, res);
     }
 
@@ -356,6 +358,8 @@ public sealed class Interpreter
         {
             case ExpectSubjectKind.Attribute:
                 {
+                    if (subj.Scope is not null)
+                        return _session.GetScopedAttributeValue(subj.Scope, subj.Name!, loc);
                     if (po is null)
                         return Fail<object?>(new Diagnostic(ErrorKind.StateNoCurrentPo, "EXPECT on an attribute needs a current PersistentObject.", loc));
                     var attr = po.GetAttribute(subj.Name!);
@@ -395,13 +399,23 @@ public sealed class Interpreter
                 }
             case ExpectSubjectKind.AttributeFlag:
                 {
-                    if (po is null)
-                        return Fail<object?>(new Diagnostic(ErrorKind.StateNoCurrentPo, "EXPECT Attribute needs a current PersistentObject.", loc));
-                    var attr = po.GetAttribute(subj.Name!);
-                    if (attr is null)
-                        return Fail<object?>(new Diagnostic(ErrorKind.ResolveAttribute,
-                            $"Attribute '{subj.Name}' does not exist on {po.Type}.", loc,
-                            Hint: Suggester.Hint(subj.Name!, po.Attributes.Select(a => a.Name))));
+                    PersistentObjectAttribute? attr;
+                    if (subj.Scope is not null)
+                    {
+                        var scoped = _session.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
+                        if (!scoped.Ok) return Fail<object?>(scoped.Error!);
+                        attr = scoped.Value!.Attribute;
+                    }
+                    else
+                    {
+                        if (po is null)
+                            return Fail<object?>(new Diagnostic(ErrorKind.StateNoCurrentPo, "EXPECT Attribute needs a current PersistentObject.", loc));
+                        attr = po.GetAttribute(subj.Name!);
+                        if (attr is null)
+                            return Fail<object?>(new Diagnostic(ErrorKind.ResolveAttribute,
+                                $"Attribute '{subj.Name}' does not exist on {po.Type}.", loc,
+                                Hint: Suggester.Hint(subj.Name!, po.Attributes.Select(a => a.Name))));
+                    }
                     return subj.Flag switch
                     {
                         AttributeFlagKind.Visible  => OpResult<object?>.Success((object?)attr.IsVisible),
@@ -432,6 +446,12 @@ public sealed class Interpreter
                 return OpResult<object?>.Success((object?)(_session.NavStackTop?.IsDialog ?? false));
             case ExpectSubjectKind.AttributeLabel:
                 {
+                    if (subj.Scope is not null)
+                    {
+                        var scoped = _session.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
+                        if (!scoped.Ok) return Fail<object?>(scoped.Error!);
+                        return OpResult<object?>.Success((object?)scoped.Value!.Attribute.Label);
+                    }
                     if (po is null)
                         return Fail<object?>(new Diagnostic(ErrorKind.StateNoCurrentPo, "EXPECT Attribute LABEL needs a current PersistentObject.", loc));
                     var attr = po.GetAttribute(subj.Name!);
@@ -491,6 +511,7 @@ public sealed class Interpreter
             case LiteralExpr l: return OpResult<object?>.Success(l.Value);
             case IdentifierExpr i: return OpResult<object?>.Success(i.Name);
             case InterpExpr interp: return EvaluateInterpolation(interp);
+            case VariableAttributeExpr v: return _session.GetScopedAttributeValue(v.Scope, v.AttributeName, v.Location);
         }
         return Fail<object?>(new Diagnostic(ErrorKind.ParseUnexpectedToken, "Unhandled expression.", expr.Location));
     }
@@ -503,6 +524,39 @@ public sealed class Interpreter
             var name = inner.Substring(5).Trim();
             var val = Environment.GetEnvironmentVariable(name);
             return OpResult<object?>.Success(val);
+        }
+        // {{@session.Attr}} — read an attribute from a reserved scoped PO. Mirrors the SET shape
+        // so authors don't need to remember a separate interpolation syntax. Scope and attribute
+        // parts are trimmed individually so {{ @session . X }} reads the same as {{@session.X}}.
+        if (inner.Length > 0 && inner[0] == '@')
+        {
+            var dot = inner.IndexOf('.');
+            if (dot < 0)
+            {
+                var bare = inner.Substring(1).Trim();
+                if (bare.Length == 0)
+                    return Fail<object?>(new Diagnostic(
+                        ErrorKind.ResolveVariable,
+                        "Empty scope in interpolation — use `{{@session.<attr>}}`.",
+                        interp.Location));
+                return Fail<object?>(new Diagnostic(
+                    ErrorKind.ResolveVariable,
+                    $"`@{bare}` is a PO reference, not a value — use `@{bare}.<attr>`.",
+                    interp.Location));
+            }
+            var scope = inner.Substring(1, dot - 1).Trim();
+            var attr = inner.Substring(dot + 1).Trim();
+            if (scope.Length == 0)
+                return Fail<object?>(new Diagnostic(
+                    ErrorKind.ResolveVariable,
+                    "Empty scope in interpolation — use `{{@session.<attr>}}`.",
+                    interp.Location));
+            if (attr.Length == 0)
+                return Fail<object?>(new Diagnostic(
+                    ErrorKind.ResolveVariable,
+                    $"`@{scope}` is a PO reference, not a value — use `@{scope}.<attr>`.",
+                    interp.Location));
+            return _session.GetScopedAttributeValue(scope, attr, interp.Location);
         }
         // {{Messages.Saved}} — look up the server-localized client message by key. Surfaces the
         // same strings the UI uses, so assertions can compare against "what the user would read"

--- a/Vidyano.Script/Runtime/Snapshot.cs
+++ b/Vidyano.Script/Runtime/Snapshot.cs
@@ -10,7 +10,8 @@ public sealed record Snapshot(
     SessionSnapshot? Session,
     PoSnapshot? Po,
     QuerySnapshot? Query,
-    IReadOnlyDictionary<string, string>? Handles);
+    IReadOnlyDictionary<string, string>? Handles,
+    PoSnapshot? SessionPo = null);
 
 /// <summary>Identifying information about the active sign-in.</summary>
 public sealed record SessionSnapshot(string? User, string? Uri);

--- a/Vidyano.Script/Runtime/VidyanoSession.cs
+++ b/Vidyano.Script/Runtime/VidyanoSession.cs
@@ -557,14 +557,22 @@ public sealed class VidyanoSession : IDisposable
     public OpResult SetAttribute(string name, object? value, SourceLocation loc, ReferenceHint? hint = null)
     {
         if (CurrentPo is null) return NoCurrentPo(loc);
+        return SetAttributeOn(CurrentPo, name, value, loc, hint);
+    }
 
-        var attr = CurrentPo.GetAttribute(name);
+    /// <summary>Sets an attribute on an explicit PO. Shared body between the implicit current-PO
+    /// path (<see cref="SetAttribute"/>) and the scoped path (<see cref="SetScopedAttribute"/>).
+    /// The only difference between callers is which PO they target — the hidden/readonly guards,
+    /// the auto-enter-edit behaviour, and the reference-resolution branch are identical.</summary>
+    private OpResult SetAttributeOn(PersistentObject po, string name, object? value, SourceLocation loc, ReferenceHint? hint)
+    {
+        var attr = po.GetAttribute(name);
         if (attr is null)
         {
-            var candidates = CurrentPo.Attributes.Select(a => a.Name);
+            var candidates = po.Attributes.Select(a => a.Name);
             return OpResult.Fail(new Diagnostic(
                 ErrorKind.ResolveAttribute,
-                $"Attribute '{name}' does not exist on {CurrentPo.Type}.",
+                $"Attribute '{name}' does not exist on {po.Type}.",
                 loc,
                 Hint: Suggester.Hint(name, candidates)));
         }
@@ -572,7 +580,7 @@ public sealed class VidyanoSession : IDisposable
         if (!attr.IsVisible)
             return OpResult.Fail(new Diagnostic(
                 ErrorKind.GuardAttributeHidden,
-                $"Attribute '{name}' exists on {CurrentPo.Type} but is hidden — the UI would not allow setting it.",
+                $"Attribute '{name}' exists on {po.Type} but is hidden — the UI would not allow setting it.",
                 loc,
                 Hint: "Use mode=direct only if you intend to bypass the UI guard.",
                 Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false }));
@@ -580,13 +588,13 @@ public sealed class VidyanoSession : IDisposable
         if (attr.IsReadOnly)
             return OpResult.Fail(new Diagnostic(
                 ErrorKind.GuardAttributeReadOnly,
-                $"Attribute '{name}' is read-only on {CurrentPo.Type}.",
+                $"Attribute '{name}' is read-only on {po.Type}.",
                 loc,
                 Hint: "Read-only attributes can be computed server-side — check the model or the action that sets it.",
                 Details: new Dictionary<string, object?> { ["attribute"] = name }));
 
-        if (!CurrentPo.IsInEdit)
-            CurrentPo.Edit();
+        if (!po.IsInEdit)
+            po.Edit();
 
         if (attr is PersistentObjectAttributeWithReference refAttr)
             return SetReferenceAttribute(refAttr, value, loc, hint);
@@ -686,6 +694,89 @@ public sealed class VidyanoSession : IDisposable
         }
     }
 
+    // --- reserved scopes (@session) -----------------------------------------------------------
+
+    /// <summary>A scoped PO + attribute pair returned by <see cref="ResolveScopedAttribute"/>.
+    /// Lets EXPECT branches reuse the same not-found / suggestion logic as SET/READ.</summary>
+    public sealed record ScopedAttribute(PersistentObject Po, PersistentObjectAttribute Attribute);
+
+    /// <summary>Resolves the PO backing a reserved variable scope. <c>"session"</c> maps to
+    /// <see cref="Vidyano.Client.Session"/>; <c>"user"</c> / <c>"application"</c> are reserved
+    /// shapes that return a not-implemented diagnostic. Anything else is rejected as unknown.</summary>
+    private OpResult<PersistentObject> ResolveScopePo(string scope, SourceLocation loc)
+    {
+        if (string.Equals(scope, "session", StringComparison.OrdinalIgnoreCase))
+        {
+            var po = Client.Session;
+            if (po is null)
+                return OpResult<PersistentObject>.Fail(new Diagnostic(
+                    ErrorKind.StateNoSession,
+                    "No Session PO on this app — `@session` is unbound.",
+                    loc,
+                    Hint: "Configure a Session PersistentObject on the server, or remove the @session reference."));
+            return OpResult<PersistentObject>.Success(po);
+        }
+        if (string.Equals(scope, "user", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(scope, "application", StringComparison.OrdinalIgnoreCase))
+        {
+            return OpResult<PersistentObject>.Fail(new Diagnostic(
+                ErrorKind.StateScopeNotImplemented,
+                $"Reserved scope '@{scope.ToLowerInvariant()}' is not yet implemented.",
+                loc,
+                Hint: "Only @session resolves in this build."));
+        }
+        return OpResult<PersistentObject>.Fail(new Diagnostic(
+            ErrorKind.ResolveVariable,
+            $"Unknown variable scope '@{scope}'.",
+            loc,
+            Hint: Suggester.Hint(scope, new[] { "session", "user", "application" })
+                  ?? "Valid scopes: @session."));
+    }
+
+    /// <summary>Resolves a scoped attribute by name, surfacing the same not-found suggestion
+    /// shape as the current-PO path. The EXPECT branches reuse this so flag/label checks share
+    /// the resolution logic with the value read.</summary>
+    public OpResult<ScopedAttribute> ResolveScopedAttribute(string scope, string attributeName, SourceLocation loc)
+    {
+        var poRes = ResolveScopePo(scope, loc);
+        if (!poRes.Ok) return OpResult<ScopedAttribute>.Fail(poRes.Error!);
+        var po = poRes.Value!;
+        var attr = po.GetAttribute(attributeName);
+        if (attr is null)
+            return OpResult<ScopedAttribute>.Fail(new Diagnostic(
+                ErrorKind.ResolveAttribute,
+                $"Attribute '{attributeName}' does not exist on @{scope} ({po.Type}).",
+                loc,
+                Hint: Suggester.Hint(attributeName, po.Attributes.Select(a => a.Name))));
+        return OpResult<ScopedAttribute>.Success(new ScopedAttribute(po, attr));
+    }
+
+    /// <summary>Reads an attribute value from a scoped PO (e.g. <c>@session.CurrentYear</c>).
+    /// Mirrors <see cref="ResolveExpectSubject"/>'s hidden-attribute guard so reads through this
+    /// path are subject to the same UI-visibility contract as the current-PO bare-name form.</summary>
+    public OpResult<object?> GetScopedAttributeValue(string scope, string attributeName, SourceLocation loc)
+    {
+        var res = ResolveScopedAttribute(scope, attributeName, loc);
+        if (!res.Ok) return OpResult<object?>.Fail(res.Error!);
+        var attr = res.Value!.Attribute;
+        if (!attr.IsVisible)
+            return OpResult<object?>.Fail(new Diagnostic(
+                ErrorKind.GuardAttributeHidden,
+                $"Attribute '{attributeName}' exists on @{scope} ({res.Value!.Po.Type}) but is hidden — the UI cannot read it.",
+                loc));
+        return OpResult<object?>.Success(attr.Value);
+    }
+
+    /// <summary>Sets an attribute on a scoped PO. Same edit/guard/reference-resolution semantics
+    /// as <see cref="SetAttribute"/>, but targeting <see cref="Vidyano.Client.Session"/> (or, in
+    /// the future, <c>@user</c>/<c>@application</c>) instead of the navigation-stack top.</summary>
+    public OpResult SetScopedAttribute(string scope, string attributeName, object? value, ReferenceHint? hint, SourceLocation loc)
+    {
+        var poRes = ResolveScopePo(scope, loc);
+        if (!poRes.Ok) return OpResult.Fail(poRes.Error!);
+        return SetAttributeOn(poRes.Value!, attributeName, value, loc, hint);
+    }
+
     /// <summary>
     /// Executes an action by name. Distinguishes: not found (typo → suggest), found but hidden,
     /// found and visible but <c>CanExecute=false</c>, transport/server error.
@@ -783,19 +874,8 @@ public sealed class VidyanoSession : IDisposable
     public Snapshot TakeSnapshot()
     {
         var session = IsSignedIn ? new SessionSnapshot(Client.User, Client.Uri) : null;
-        var po = CurrentPo is null ? null : new PoSnapshot(
-            Type: CurrentPo.Type,
-            ObjectId: CurrentPo.ObjectId,
-            IsInEdit: CurrentPo.IsInEdit,
-            IsDirty: CurrentPo.IsDirty,
-            IsNew: CurrentPo.IsNew,
-            Notification: CurrentPo.Notification,
-            NotificationType: CurrentPo.HasNotification ? CurrentPo.NotificationType.ToString() : null,
-            Attributes: CurrentPo.Attributes.Select(a => new AttributeSnapshot(
-                a.Name, a.Type, a.ValueDirect, SafeDisplay(a),
-                a.IsVisible, a.IsReadOnly, a.IsRequired, a.IsValueChanged, a.ValidationError)).ToList(),
-            Actions: CurrentPo.Actions.Concat(CurrentPo.PinnedActions)
-                .Select(a => new ActionSnapshot(a.Name, a.CanExecute, a.IsVisible)).ToList());
+        var po = CurrentPo is { } cur ? BuildPoSnapshot(cur) : null;
+        var sessionPo = Client.Session is { } sess ? BuildPoSnapshot(sess) : null;
 
         var query = CurrentQuery is null ? null : new QuerySnapshot(
             Name: CurrentQuery.Name,
@@ -810,8 +890,22 @@ public sealed class VidyanoSession : IDisposable
         IReadOnlyDictionary<string, string>? handles = _handles.Count == 0 ? null
             : _handles.ToDictionary(kv => kv.Key, kv => DescribeHandle(kv.Value));
 
-        return new Snapshot(session, po, query, handles);
+        return new Snapshot(session, po, query, handles, sessionPo);
     }
+
+    private static PoSnapshot BuildPoSnapshot(PersistentObject po) => new(
+        Type: po.Type,
+        ObjectId: po.ObjectId,
+        IsInEdit: po.IsInEdit,
+        IsDirty: po.IsDirty,
+        IsNew: po.IsNew,
+        Notification: po.Notification,
+        NotificationType: po.HasNotification ? po.NotificationType.ToString() : null,
+        Attributes: po.Attributes.Select(a => new AttributeSnapshot(
+            a.Name, a.Type, a.ValueDirect, SafeDisplay(a),
+            a.IsVisible, a.IsReadOnly, a.IsRequired, a.IsValueChanged, a.ValidationError)).ToList(),
+        Actions: po.Actions.Concat(po.PinnedActions)
+            .Select(a => new ActionSnapshot(a.Name, a.CanExecute, a.IsVisible)).ToList());
 
     private static string? SafeDisplay(PersistentObjectAttribute attr)
     {


### PR DESCRIPTION
## Summary

Adds a reserved `@session` script variable to `.visc`, auto-bound to `Client.Session` (the built-in Vidyano session PO that auto-roundtrips with every request). Lets scripts read and write attributes on Session without leaving the current nav frame — mirroring the user-facing model where Session is always-visible chrome the user mutates inline.

Stacked on #7. Targets `feat/script-tool` until #7 merges; will rebase onto `main` after.

## Syntax

```visc
SET @session.Patient = LOOKUP "Naam:Smith"     # write
SET Year = @session.CurrentYear                # read in value position
EXPECT @session.Patient CONTAINS "Smith"       # EXPECT subject
EXPECT Attribute @session.Patient IS REQUIRED  # flag check
SEARCH "Patient.Id:{{@session.Patient}}"       # interpolation
```

`session`, `user`, `application` are reserved. `@session = …` is a parse error; `@user` / `@application` parse but resolve to a runtime diagnostic (`StateScopeNotImplemented`) until they're wired up. Handles that collide with reserved scopes (e.g. `SIGN-IN @session = …`) are also rejected — same `ReservedScopes` source of truth, enforced at every binding site.

## What's in the box

- **Parser**: `@<scope>.<attr>` recognised in SET targets, SET values, EXPECT subjects, `EXPECT Attribute` flag/label checks. Reserved-name set is one `HashSet` consumed everywhere a name becomes a binding.
- **Interpreter**: `@session` resolves to `Client.Session` at runtime (re-read per call, no caching). Clean diagnostics for null Session (`StateNoSession`), missing attribute (`ResolveAttribute` + did-you-mean), hidden/read-only on write (`GuardAttributeHidden` / `GuardAttributeReadOnly`).
- **`VidyanoSession`**: three new public methods — `GetScopedAttributeValue`, `SetScopedAttribute`, `ResolveScopedAttribute`. The existing `SetAttribute(name, value, loc, hint)` signature is preserved; both code paths share a private `SetAttributeOn(po, …)` helper for the guard / edit / reference logic.
- **`Snapshot`**: new `SessionPo: PoSnapshot?` field, populated from `Client.Session` when non-null. Rendered by `--verbose` in `ConsoleReporter` parallel to `Po`.
- **Dotted attribute names** also generalised — `SET Customer.Name = …` now parses everywhere a single-attribute name was previously accepted. One shared `ParseDottedAttributeName` helper at all four sites.
- **New sample**: `Vidyano.Script.Tool/samples/session-scope.visc`. Lints clean; runtime block is commented behind a `Session-required` gate until the local Raven sample exposes a Session PO.

## Test plan

- [x] `dotnet build Vidyano.Core.sln -c Debug` — 0 warnings, 0 errors across netstandard2.0 / net8.0 / net10.0.
- [x] All five samples lint clean (`vidyano lint …`).
- [x] Existing regression samples stay green against the local Raven fixture: `nav-stack` 37/37, `client-ops` 17/17, `localization` 17/17, `env-web` 4/4.
- [x] Reserved-handle guard fires: `SIGN-IN @session = …` produces `parse-unexpected-token` with `'@session' is reserved and can't be used as a SIGN-IN handle.`
- [ ] Wire `session-scope.visc` runtime block to a real Session PO on the Raven sample (follow-up).

## Pipeline gates

Implemented via `/implement-issue`. Reviewer flagged 3 should-fix items (reserved-handle gap, dead `SessionPo` field, overloaded ErrorKind) + 7 nits — all addressed in this commit. Verifier confirmed all 37 spec items satisfied.

## Versioning

Pinned to `Vidyano.Core` and `Vidyano.Script` via `ProjectReference` — bump in lockstep with PR #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)