### PR TITLE
feat: expose server Initial PO (OnLogin gate) on Client

### DIFF
--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -73,9 +74,13 @@ namespace Vidyano
 
         private readonly HttpClient httpClient;
 
-        private PersistentObject _Application, _Session;
+        private PersistentObject _Application, _Session, _Initial;
         private bool _IsBusy, _IsConnected, _IsUsingDefaultCredentials;
         private KeyValueList<string, string> _Messages;
+
+        private event Action<ClientOperation> ClientOperationDispatched;
+
+        private readonly SemaphoreSlim _initialGate = new SemaphoreSlim(1, 1);
 
         #endregion
 
@@ -163,6 +168,21 @@ namespace Vidyano
         {
             get => _Session;
             set => SetProperty(ref _Session, value);
+        }
+
+        /// <summary>
+        /// The Initial <see cref="PersistentObject"/> returned by <c>GetApplication</c> when the
+        /// server gates the application behind a one-shot PO — for example license-terms acceptance,
+        /// forced two-factor enrolment, or a forced password reset. Unlike <see cref="Session"/> this
+        /// is a one-shot: it is populated during sign-in (and during
+        /// <see cref="ReestablishSessionAsync"/>) and cleared after the gate is satisfied; it is
+        /// never auto-roundtripped on subsequent requests. Callers that ignore this property bypass
+        /// the gate — use <see cref="EnsureInitialSatisfiedAsync"/> to honour it.
+        /// </summary>
+        public PersistentObject Initial
+        {
+            get => _Initial;
+            private set => SetProperty(ref _Initial, value);
         }
 
         public string Uri { get; set; }
@@ -334,7 +354,11 @@ namespace Vidyano
                 return;
 
             foreach (var raw in ops.OfType<JObject>())
-                Hooks?.OnClientOperation(ClientOperation.FromJson(raw));
+            {
+                var op = ClientOperation.FromJson(raw);
+                Hooks?.OnClientOperation(op);
+                ClientOperationDispatched?.Invoke(op);
+            }
         }
 
         public Task<PersistentObject> SignInUsingAccessTokenAsync(string accessToken, string serviceProvider = "Microsoft")
@@ -365,31 +389,36 @@ namespace Vidyano
             return SignInAsync(null, null);
         }
 
-        private async Task<PersistentObject> SignInAsync(string user, string password, string token = null, string accessToken = null, string serviceProvider = null)
+        private Task<PersistentObject> SignInAsync(string user, string password, string token = null, string accessToken = null, string serviceProvider = null)
         {
             if (Hooks == null)
                 throw new InvalidOperationException("Need to set Hooks property first.");
 
+            var data = CreateData(user, token);
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                if (password != null)
+                {
+                    data["password"] = password;
+                    data.Remove("authToken");
+                }
+            }
+            else
+            {
+                data.Remove("userName");
+                data.Remove("authToken");
+                data["accessToken"] = accessToken;
+                data["serviceProvider"] = serviceProvider;
+            }
+
+            return LoadApplicationAsync(data, user);
+        }
+
+        private async Task<PersistentObject> LoadApplicationAsync(JObject data, string user = null)
+        {
             try
             {
                 IsBusy = true;
-
-                var data = CreateData(user, token);
-                if (string.IsNullOrEmpty(accessToken))
-                {
-                    if (password != null)
-                    {
-                        data["password"] = password;
-                        data.Remove("authToken");
-                    }
-                }
-                else
-                {
-                    data.Remove("userName");
-                    data.Remove("authToken");
-                    data["accessToken"] = accessToken;
-                    data["serviceProvider"] = serviceProvider;
-                }
 
                 var response = await PostAsync("GetApplication", data).ConfigureAwait(false);
 
@@ -407,6 +436,16 @@ namespace Vidyano
                 AuthToken = (string)response["authToken"];
 
                 Application = po;
+
+                if (response["initial"] is JObject initialJson)
+                {
+                    var initialPo = Hooks.OnConstruct(this, initialJson);
+                    if (initialPo.FullTypeName == "Vidyano.Error" || (initialPo.NotificationType == NotificationType.Error && !string.IsNullOrEmpty(initialPo.Notification)))
+                        throw new Exception(initialPo.Notification);
+                    Initial = initialPo;
+                }
+                else
+                    Initial = null;
 
                 var cultureInfo = new CultureInfo(Application["Culture"].ValueDirect);
                 CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
@@ -730,6 +769,112 @@ namespace Vidyano
 
         #region Public Methods
 
+        /// <summary>
+        /// Drives the one-shot <see cref="Initial"/> gate to completion: invokes
+        /// <see cref="Hooks.OnInitialRequired"/>, waits for the server's <c>reloadPage</c>
+        /// ClientOperation, then re-establishes the session via <see cref="ReestablishSessionAsync"/>.
+        /// Loops until <see cref="Initial"/> is null on return — so chained gates (e.g. terms then
+        /// forced password reset) are all satisfied in one call. Returns immediately when there is
+        /// no gate to satisfy. <see cref="Hooks.OnInitialRequired"/> is responsible for SAVE-ing the
+        /// PO (directly or by parking it for a user-driven flow); the wait honours the supplied
+        /// <paramref name="ct"/> during both the hook await and the <c>reloadPage</c> wait.
+        /// </summary>
+        /// <remarks>
+        /// Concurrent invocations on the same <see cref="Client"/> are serialised internally so the
+        /// gate handshake runs once at a time. The <c>reloadPage</c> wait matches any ClientOperation
+        /// with that name dispatched after the hook is invoked — in practice only the server-side
+        /// gate-satisfaction handler emits it, but consumers that rely on <c>reloadPage</c> for other
+        /// purposes should not call this concurrently with that traffic.
+        /// </remarks>
+        public async Task EnsureInitialSatisfiedAsync(CancellationToken ct = default)
+        {
+            await _initialGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                while (Initial != null)
+                {
+                    var pending = Initial;
+                    var reloadTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                    void Listener(ClientOperation op)
+                    {
+                        if (op is ExecuteMethodClientOperation execute && execute.Name == "reloadPage")
+                            reloadTcs.TrySetResult(true);
+                    }
+
+                    // Register the listener BEFORE invoking the hook: if OnInitialRequired SAVEs the PO
+                    // inline, the reloadPage operation arrives during that await.
+                    ClientOperationDispatched += Listener;
+                    try
+                    {
+                        await Hooks.OnInitialRequired(pending).ConfigureAwait(false);
+
+                        ct.ThrowIfCancellationRequested();
+
+                        await WaitWithCancellationAsync(reloadTcs.Task, ct).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        ClientOperationDispatched -= Listener;
+                    }
+
+                    await ReestablishSessionAsync(ct).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                _initialGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Re-runs <c>GetApplication</c> under the current <see cref="AuthToken"/>, refreshing
+        /// <see cref="Application"/>, <see cref="Session"/>, <see cref="Initial"/>, <c>Messages</c>
+        /// and <c>Actions</c>. The escape hatch for advanced callers that drove <see cref="Initial"/>
+        /// to SAVE themselves (multi-step wizards, custom flows) and now need to clear the gate
+        /// without going through <see cref="EnsureInitialSatisfiedAsync"/>. Idempotent for serial use
+        /// — call it repeatedly to refresh, but do not run two refreshes concurrently on the same
+        /// <see cref="Client"/>.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="ct"/> is honoured only at the call boundary: once the underlying
+        /// <c>GetApplication</c> POST is in flight it cannot be interrupted via this token. Use the
+        /// <see cref="HttpClient"/> handed to the <see cref="Client"/> constructor if you need to
+        /// cancel the network request itself.
+        /// </remarks>
+        public Task ReestablishSessionAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return LoadApplicationAsync(CreateData());
+        }
+
+        /// <summary>
+        /// Polyfill for <c>Task.WaitAsync(CancellationToken)</c>, which is unavailable on
+        /// netstandard2.0. Awaits <paramref name="task"/> while honouring <paramref name="ct"/>;
+        /// throws <see cref="OperationCanceledException"/> if the token fires before the task
+        /// completes. The token registration is disposed eagerly so it does not leak for the
+        /// remaining lifetime of <paramref name="ct"/> when the task wins the race. Only used
+        /// against TCS-backed tasks that cannot fault, so post-cancellation faults are not observed.
+        /// </summary>
+        private static async Task WaitWithCancellationAsync(Task task, CancellationToken ct)
+        {
+            if (!ct.CanBeCanceled)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (ct.Register(static state => ((TaskCompletionSource<bool>)state).TrySetResult(true), tcs))
+            {
+                var completed = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
+                if (completed != task)
+                    ct.ThrowIfCancellationRequested();
+            }
+
+            await task.ConfigureAwait(false);
+        }
+
         public async Task SignOut()
         {
             // Try to call viSignOut action on the Application before clearing auth tokens
@@ -748,6 +893,7 @@ namespace Vidyano
 
             // Clear local state
             Application = null;
+            Initial = null;
             User = string.Empty;
             AuthToken = null;
             AuthorizationHeader = null;

--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -77,10 +76,6 @@ namespace Vidyano
         private PersistentObject _Application, _Session, _Initial;
         private bool _IsBusy, _IsConnected, _IsUsingDefaultCredentials;
         private KeyValueList<string, string> _Messages;
-
-        private event Action<ClientOperation> ClientOperationDispatched;
-
-        private readonly SemaphoreSlim _initialGate = new SemaphoreSlim(1, 1);
 
         #endregion
 
@@ -172,12 +167,13 @@ namespace Vidyano
 
         /// <summary>
         /// The Initial <see cref="PersistentObject"/> returned by <c>GetApplication</c> when the
-        /// server gates the application behind a one-shot PO — for example license-terms acceptance,
-        /// forced two-factor enrolment, or a forced password reset. Unlike <see cref="Session"/> this
-        /// is a one-shot: it is populated during sign-in (and during
-        /// <see cref="ReestablishSessionAsync"/>) and cleared after the gate is satisfied; it is
-        /// never auto-roundtripped on subsequent requests. Callers that ignore this property bypass
-        /// the gate — use <see cref="EnsureInitialSatisfiedAsync"/> to honour it.
+        /// server gates the application behind a one-shot PO — for example license-terms
+        /// acceptance, forced two-factor enrolment, or a forced password reset. Populated during
+        /// sign-in; <c>null</c> when the server emits no gate. Drive the PO to a successful
+        /// <c>Save</c> (or otherwise resolve it) and then call <see cref="ClearInitial"/> to
+        /// signal the rest of the client that the gate is done; the v4 frontend's sign-in
+        /// component follows the same pattern. Never auto-roundtripped on subsequent requests.
+        /// Callers that ignore this property bypass the gate entirely.
         /// </summary>
         public PersistentObject Initial
         {
@@ -354,11 +350,7 @@ namespace Vidyano
                 return;
 
             foreach (var raw in ops.OfType<JObject>())
-            {
-                var op = ClientOperation.FromJson(raw);
-                Hooks?.OnClientOperation(op);
-                ClientOperationDispatched?.Invoke(op);
-            }
+                Hooks?.OnClientOperation(ClientOperation.FromJson(raw));
         }
 
         public Task<PersistentObject> SignInUsingAccessTokenAsync(string accessToken, string serviceProvider = "Microsoft")
@@ -389,36 +381,31 @@ namespace Vidyano
             return SignInAsync(null, null);
         }
 
-        private Task<PersistentObject> SignInAsync(string user, string password, string token = null, string accessToken = null, string serviceProvider = null)
+        private async Task<PersistentObject> SignInAsync(string user, string password, string token = null, string accessToken = null, string serviceProvider = null)
         {
             if (Hooks == null)
                 throw new InvalidOperationException("Need to set Hooks property first.");
 
-            var data = CreateData(user, token);
-            if (string.IsNullOrEmpty(accessToken))
-            {
-                if (password != null)
-                {
-                    data["password"] = password;
-                    data.Remove("authToken");
-                }
-            }
-            else
-            {
-                data.Remove("userName");
-                data.Remove("authToken");
-                data["accessToken"] = accessToken;
-                data["serviceProvider"] = serviceProvider;
-            }
-
-            return LoadApplicationAsync(data, user);
-        }
-
-        private async Task<PersistentObject> LoadApplicationAsync(JObject data, string user = null)
-        {
             try
             {
                 IsBusy = true;
+
+                var data = CreateData(user, token);
+                if (string.IsNullOrEmpty(accessToken))
+                {
+                    if (password != null)
+                    {
+                        data["password"] = password;
+                        data.Remove("authToken");
+                    }
+                }
+                else
+                {
+                    data.Remove("userName");
+                    data.Remove("authToken");
+                    data["accessToken"] = accessToken;
+                    data["serviceProvider"] = serviceProvider;
+                }
 
                 var response = await PostAsync("GetApplication", data).ConfigureAwait(false);
 
@@ -770,109 +757,14 @@ namespace Vidyano
         #region Public Methods
 
         /// <summary>
-        /// Drives the one-shot <see cref="Initial"/> gate to completion: invokes
-        /// <see cref="Hooks.OnInitialRequired"/>, waits for the server's <c>reloadPage</c>
-        /// ClientOperation, then re-establishes the session via <see cref="ReestablishSessionAsync"/>.
-        /// Loops until <see cref="Initial"/> is null on return — so chained gates (e.g. terms then
-        /// forced password reset) are all satisfied in one call. Returns immediately when there is
-        /// no gate to satisfy. <see cref="Hooks.OnInitialRequired"/> is responsible for SAVE-ing the
-        /// PO (directly or by parking it for a user-driven flow); the wait honours the supplied
-        /// <paramref name="ct"/> during both the hook await and the <c>reloadPage</c> wait.
+        /// Sets <see cref="Initial"/> to <c>null</c>. Mirrors the v4 frontend's
+        /// <c>service.clearInitial()</c>: after driving the gate PO to a successful <c>Save</c> (or
+        /// otherwise resolving it), call this so the rest of the client sees a gate-free state.
+        /// No-op when <see cref="Initial"/> is already <c>null</c>.
         /// </summary>
-        /// <remarks>
-        /// Concurrent invocations on the same <see cref="Client"/> are serialised internally so the
-        /// gate handshake runs once at a time. The <c>reloadPage</c> wait matches any ClientOperation
-        /// with that name dispatched after the hook is invoked — in practice only the server-side
-        /// gate-satisfaction handler emits it, but consumers that rely on <c>reloadPage</c> for other
-        /// purposes should not call this concurrently with that traffic.
-        /// </remarks>
-        public async Task EnsureInitialSatisfiedAsync(CancellationToken ct = default)
+        public void ClearInitial()
         {
-            await _initialGate.WaitAsync(ct).ConfigureAwait(false);
-            try
-            {
-                while (Initial != null)
-                {
-                    var pending = Initial;
-                    var reloadTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                    void Listener(ClientOperation op)
-                    {
-                        if (op is ExecuteMethodClientOperation execute && execute.Name == "reloadPage")
-                            reloadTcs.TrySetResult(true);
-                    }
-
-                    // Register the listener BEFORE invoking the hook: if OnInitialRequired SAVEs the PO
-                    // inline, the reloadPage operation arrives during that await.
-                    ClientOperationDispatched += Listener;
-                    try
-                    {
-                        await Hooks.OnInitialRequired(pending).ConfigureAwait(false);
-
-                        ct.ThrowIfCancellationRequested();
-
-                        await WaitWithCancellationAsync(reloadTcs.Task, ct).ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        ClientOperationDispatched -= Listener;
-                    }
-
-                    await ReestablishSessionAsync(ct).ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                _initialGate.Release();
-            }
-        }
-
-        /// <summary>
-        /// Re-runs <c>GetApplication</c> under the current <see cref="AuthToken"/>, refreshing
-        /// <see cref="Application"/>, <see cref="Session"/>, <see cref="Initial"/>, <c>Messages</c>
-        /// and <c>Actions</c>. The escape hatch for advanced callers that drove <see cref="Initial"/>
-        /// to SAVE themselves (multi-step wizards, custom flows) and now need to clear the gate
-        /// without going through <see cref="EnsureInitialSatisfiedAsync"/>. Idempotent for serial use
-        /// — call it repeatedly to refresh, but do not run two refreshes concurrently on the same
-        /// <see cref="Client"/>.
-        /// </summary>
-        /// <remarks>
-        /// <paramref name="ct"/> is honoured only at the call boundary: once the underlying
-        /// <c>GetApplication</c> POST is in flight it cannot be interrupted via this token. Use the
-        /// <see cref="HttpClient"/> handed to the <see cref="Client"/> constructor if you need to
-        /// cancel the network request itself.
-        /// </remarks>
-        public Task ReestablishSessionAsync(CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return LoadApplicationAsync(CreateData());
-        }
-
-        /// <summary>
-        /// Polyfill for <c>Task.WaitAsync(CancellationToken)</c>, which is unavailable on
-        /// netstandard2.0. Awaits <paramref name="task"/> while honouring <paramref name="ct"/>;
-        /// throws <see cref="OperationCanceledException"/> if the token fires before the task
-        /// completes. The token registration is disposed eagerly so it does not leak for the
-        /// remaining lifetime of <paramref name="ct"/> when the task wins the race. Only used
-        /// against TCS-backed tasks that cannot fault, so post-cancellation faults are not observed.
-        /// </summary>
-        private static async Task WaitWithCancellationAsync(Task task, CancellationToken ct)
-        {
-            if (!ct.CanBeCanceled)
-            {
-                await task.ConfigureAwait(false);
-                return;
-            }
-
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            using (ct.Register(static state => ((TaskCompletionSource<bool>)state).TrySetResult(true), tcs))
-            {
-                var completed = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
-                if (completed != task)
-                    ct.ThrowIfCancellationRequested();
-            }
-
-            await task.ConfigureAwait(false);
+            Initial = null;
         }
 
         public async Task SignOut()

--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -427,7 +427,7 @@ namespace Vidyano
                 if (response["initial"] is JObject initialJson)
                 {
                     var initialPo = Hooks.OnConstruct(this, initialJson);
-                    if (initialPo.FullTypeName == "Vidyano.Error" || (initialPo.NotificationType == NotificationType.Error && !string.IsNullOrEmpty(initialPo.Notification)))
+                    if (initialPo.FullTypeName == "Vidyano.Error" || (initialPo.HasNotification && initialPo.NotificationType == NotificationType.Error))
                         throw new Exception(initialPo.Notification);
                     Initial = initialPo;
                 }
@@ -738,7 +738,7 @@ namespace Vidyano
             if (response["session"] != null)
             {
                 var sessionPo = Hooks.OnConstruct(this, (JObject)response["session"]);
-                if (sessionPo.FullTypeName == "Vidyano.Error" || (sessionPo.NotificationType == NotificationType.Error && !string.IsNullOrEmpty(sessionPo.Notification)))
+                if (sessionPo.FullTypeName == "Vidyano.Error" || (sessionPo.HasNotification && sessionPo.NotificationType == NotificationType.Error))
                     throw new Exception(sessionPo.Notification);
 
                 if (Session != null)

--- a/Vidyano.Core/Hooks.cs
+++ b/Vidyano.Core/Hooks.cs
@@ -86,6 +86,22 @@ namespace Vidyano
         {
         }
 
+        /// <summary>
+        /// Called by <see cref="Client.EnsureInitialSatisfiedAsync"/> when the server returned an
+        /// Initial <see cref="PersistentObject"/> that gates the application (license terms, forced
+        /// two-factor enrolment, forced password reset, …). Override to render the PO and drive it
+        /// to completion — typically by executing its <c>Save</c> action. Return a <see cref="Task"/>
+        /// that completes once the gate has been resolved; <see cref="Client.EnsureInitialSatisfiedAsync"/>
+        /// then waits for the server's <c>reloadPage</c> ClientOperation and re-establishes the
+        /// session. The default implementation is a no-op, which leaves <see cref="Client.Initial"/>
+        /// untouched and causes <see cref="Client.EnsureInitialSatisfiedAsync"/> to hang on the
+        /// <c>reloadPage</c> wait — override it whenever you opt into the gate flow.
+        /// </summary>
+        protected internal virtual Task OnInitialRequired(PersistentObject initial)
+        {
+            return Task.CompletedTask;
+        }
+
         internal virtual object ByteArrayToImageSource(MemoryStream memoryStream)
         {
             return null;

--- a/Vidyano.Core/Hooks.cs
+++ b/Vidyano.Core/Hooks.cs
@@ -86,22 +86,6 @@ namespace Vidyano
         {
         }
 
-        /// <summary>
-        /// Called by <see cref="Client.EnsureInitialSatisfiedAsync"/> when the server returned an
-        /// Initial <see cref="PersistentObject"/> that gates the application (license terms, forced
-        /// two-factor enrolment, forced password reset, …). Override to render the PO and drive it
-        /// to completion — typically by executing its <c>Save</c> action. Return a <see cref="Task"/>
-        /// that completes once the gate has been resolved; <see cref="Client.EnsureInitialSatisfiedAsync"/>
-        /// then waits for the server's <c>reloadPage</c> ClientOperation and re-establishes the
-        /// session. The default implementation is a no-op, which leaves <see cref="Client.Initial"/>
-        /// untouched and causes <see cref="Client.EnsureInitialSatisfiedAsync"/> to hang on the
-        /// <c>reloadPage</c> wait — override it whenever you opt into the gate flow.
-        /// </summary>
-        protected internal virtual Task OnInitialRequired(PersistentObject initial)
-        {
-            return Task.CompletedTask;
-        }
-
         internal virtual object ByteArrayToImageSource(MemoryStream memoryStream)
         {
             return null;

--- a/docs/design/initial-po.md
+++ b/docs/design/initial-po.md
@@ -1,0 +1,132 @@
+# Design: Expose server Initial PO (OnLogin gate) on `Client`
+
+> ✅ Design phase complete (`/design-interface`)
+
+## Problem
+
+The Vidyano backend supports an **Initial PO** — a `PersistentObject` returned by `Advanced.OnLogin(LoginArgs)` (and the built-in `Vidyano.UserSettings/OnLogin` path) that should block the client until the user satisfies a gate. Use cases:
+
+- License-terms acceptance before the app loads.
+- Forced two-factor enrolment for users in a `TwoFactorRequired` group.
+- Forced password reset (`User.ResetPasswordNextLogin`).
+
+Server-side wiring exists (Vidyano.Service repo, for reference):
+
+- `Vidyano.Service\Advanced.cs:809` — `OnLogin(LoginArgs) → PersistentObject?` hook.
+- `Vidyano.Service\WebController.cs:645` — populates `GetApplicationResult.Initial`.
+- `Vidyano.Service\WebController.Results.cs:107` — `[DataMember] public PersistentObject Initial { get; set; }`.
+- `Vidyano.Service\Repository\UserSettingsActions.cs:448-449` — server signals satisfaction by queuing `ExecuteMethodOperation.ReloadPage()` once the gate is cleared.
+
+**Vidyano.Core silently discards `response["initial"]`** (`Vidyano.Core\Client.cs:394` reads `application`, `userName`, `userPicture`, `authToken`, and `session` from the GetApplication response — never `initial`). Every consumer — including `Vidyano.Script` — bypasses these gates.
+
+## Constraints any design must satisfy
+
+1. Expose the Initial PO post-SignIn — observable by callers.
+2. **Not** auto-roundtripped on subsequent requests (unlike `Session`); it's a one-shot screen.
+3. Discovery without polling.
+4. Satisfaction protocol: server queues `ExecuteMethod` ClientOperation with `Name == "reloadPage"` when the gate is cleared → Vidyano.Core must offer a way to re-establish the session in response.
+5. Symmetry with `Client.Application` / `Client.Session`.
+6. Backwards-compat: callers that don't check `Initial` keep working (they bypass gates, with documented warning).
+
+## Chosen interface
+
+```csharp
+// Vidyano.Core\Client.cs — additions alongside Application / Session
+public PersistentObject Initial { get; private set; }   // observable; set during GetApplication, cleared after ReloadPage
+public Task EnsureInitialSatisfiedAsync(CancellationToken ct = default);
+public Task ReestablishSessionAsync(CancellationToken ct = default);
+
+// Vidyano.Core\Hooks.cs — one new hook (THE extension point)
+protected internal virtual Task OnInitialRequired(PersistentObject initial) => Task.CompletedTask;
+```
+
+### Behavior
+
+- **`Initial`** — set in `GetApplicationAsync` immediately after `Application = po;` from `response["initial"]` (null when omitted). `private set` + `SetProperty` so XAML/Avalonia bindings + `INotifyPropertyChanged` work. Cleared by `SignOut`.
+- **`EnsureInitialSatisfiedAsync(ct)`** — the common-case one-liner.
+  - If `Initial == null`: returns immediately.
+  - Otherwise: calls `Hooks.OnInitialRequired(Initial)`, awaits the returned `Task`, then waits internally for the server's `ReloadPage` ClientOperation, re-runs `GetApplication` under the existing `AuthToken`, and returns. `Initial` is `null` on return.
+- **`ReestablishSessionAsync(ct)`** — escape hatch for advanced callers that drove the Initial PO to SAVE themselves (multi-step wizard, custom flow). Performs only the re-run-GetApplication step. Idempotent.
+- **`Hooks.OnInitialRequired(po)`** — default no-op. Custom hosts override to render the PO; `Vidyano.Script` overrides to park the PO and complete when the script SAVEs the gate.
+
+### Satisfaction handshake (concrete protocol)
+
+1. `GetApplicationAsync` reads `response["initial"]` → `Initial = Hooks.OnConstruct(this, json)`.
+2. Caller drives the PO (typically `Initial.Actions["Save"].Execute()`), either directly or via `EnsureInitialSatisfiedAsync` → `Hooks.OnInitialRequired`.
+3. Server action handler clears the gate and queues `ExecuteMethodOperation.ReloadPage()`.
+4. The operation flows through the existing `Hooks.OnClientOperation` pipeline. `EnsureInitialSatisfiedAsync` has an internal `TaskCompletionSource` listening for that op.
+5. On match: re-run `GetApplication` (preserves `AuthToken`), refresh `Application` / `Session` / `Messages` / `Actions`, null `Initial`, return.
+
+The handshake reuses two existing rails (PO action execution + `OnClientOperation`). No new wire protocol.
+
+### Usage
+
+```csharp
+// 95% caller — custom .NET host / Vidyano.Script
+class ScriptHooks : Hooks
+{
+    protected override Task OnInitialRequired(PersistentObject po)
+        => scriptRunner.HandleAsync(po);   // saves the PO, or throws on strict
+}
+
+await client.SignInUsingCredentialsAsync(user, pwd);
+await client.EnsureInitialSatisfiedAsync();   // <-- the one line
+// From here on Application/Session are guaranteed gate-free.
+
+// Advanced caller — multi-step wizard drives Save itself
+await client.SignInUsingCredentialsAsync(user, pwd);
+if (client.Initial != null)
+{
+    await myMultiStepWizard.Run(client.Initial);
+    await client.ReestablishSessionAsync();   // explicit re-handshake
+}
+```
+
+## Vidyano.Script follow-up (separate PR)
+
+Falls out cleanly from this design — sketched here for traceability, not in scope for the Vidyano.Core PR:
+
+- New `@initial` reserved variable, parallel to `@session`.
+- `VidyanoScriptHooks.OnInitialRequired(po)` parks `Client.Initial` as `@initial` and returns a `Task` that completes when the script SAVEs it (or errors out in strict mode).
+- Until `@initial == null`, non-initial verbs error with `state-initial-pending`; escape via `@mode = direct`.
+
+## Designs considered (and rejected)
+
+### Rejected — Minimal surface (one property, nothing else)
+
+Expose `Client.Initial` and stop. Each caller subscribes to `OnClientOperation`, filters for `ExecuteMethodOperation` with `Name == "reloadPage"`, re-calls `GetApplication`, handles re-entrancy.
+
+**Why rejected:** punts the entire satisfaction protocol onto every consumer. The `ReloadPage` mechanism is one concrete protocol — Vidyano.Core should own it, not document it as a recipe. Inverts "pull complexity downwards."
+
+### Rejected — Strategy pattern / maximize flexibility
+
+`IInitialStrategy` interface + `DefaultInitialStrategy` / `AutoSaveInitialStrategy` / `RequireExplicitInitialStrategy` + `InitialContext` (with `Disposition`/`Replacement`) + `InitialReloadMode` enum (4 modes) + 3 new hooks (`OnInitialReceiving`, `OnInitialReceived`, `OnInitialSatisfied`) + internal `InitialCoordinator`.
+
+**Why rejected:** ~12 surface types for two known consumer shapes (Vidyano.Script + custom host) that want essentially the same thing — "block until handled, then proceed." Premature framework-building; the 4×3 reload/disposition matrix solves problems we haven't seen and creates problems we will see.
+
+### Rejected — Common-case design, as originally drafted
+
+Same shape as the chosen design plus `AcknowledgeInitialBypass(reason)` (with a "warn on next mutation" side-channel through `OnException`) and `Hooks.OnInitialSatisfied()`.
+
+**Why partially rejected:** the bypass-warning channel is speculative and confuses errors with warnings; a caller who ignores `Client.Initial` chose to bypass — XML-doc the consequence. `OnInitialSatisfied` is redundant with `INotifyPropertyChanged` firing when `Initial` goes null. Both dropped from the chosen shape.
+
+## Tasks
+
+- [ ] `Client.cs` — add `Initial` property with `SetProperty`/private setter, parallel to `Session` (line ~162).
+- [ ] `Client.cs` `GetApplicationAsync` — set `Initial` from `response["initial"]` after `Application = po;` (line ~409).
+- [ ] `Client.cs` `SignOut` — null out `Initial` (line ~750).
+- [ ] `Client.cs` — implement `EnsureInitialSatisfiedAsync(CancellationToken)`: invokes `Hooks.OnInitialRequired(Initial)`, awaits, then waits for a `ReloadPage` `ExecuteMethodClientOperation` via internal `TaskCompletionSource`, re-runs `GetApplication` under existing `AuthToken`, returns.
+- [ ] `Client.cs` — implement `ReestablishSessionAsync(CancellationToken)` as the re-run-GetApplication portion of the above.
+- [ ] `Hooks.cs` — add `OnInitialRequired(PersistentObject) → Task` virtual hook with XML doc explaining the contract (return a Task that completes once the gate has been driven to Save / otherwise resolved).
+- [ ] XML doc on `Initial`: one-shot, not auto-roundtripped, casual callers bypass the gate if they ignore it.
+- [ ] Tests:
+  - Sign-in with no Initial → `Initial == null`, `EnsureInitialSatisfiedAsync` is a no-op.
+  - Sign-in with Initial → `Initial` non-null; `OnInitialRequired` fires; SAVE → `ReloadPage` → `Initial` cleared.
+  - `ReestablishSessionAsync` after caller-driven SAVE clears `Initial`.
+  - Cancellation token honoured during both the hook await and the `ReloadPage` wait.
+  - `SignOut` clears `Initial`.
+
+## Related
+
+- Server-side surface is already in place; this is purely a Vidyano.Core consumer-side change.
+- Natural sibling to PR #8 (`@session` reserved variable). The Vidyano.Script `@initial` follow-up will reference this once landed.

--- a/docs/design/initial-po.md
+++ b/docs/design/initial-po.md
@@ -1,6 +1,6 @@
 # Design: Expose server Initial PO (OnLogin gate) on `Client`
 
-> ✅ Design phase complete (`/design-interface`)
+> ✅ Design phase complete (`/design-interface`) — protocol corrected after reading the v4 sign-in component.
 
 ## Problem
 
@@ -15,115 +15,93 @@ Server-side wiring exists (Vidyano.Service repo, for reference):
 - `Vidyano.Service\Advanced.cs:809` — `OnLogin(LoginArgs) → PersistentObject?` hook.
 - `Vidyano.Service\WebController.cs:645` — populates `GetApplicationResult.Initial`.
 - `Vidyano.Service\WebController.Results.cs:107` — `[DataMember] public PersistentObject Initial { get; set; }`.
-- `Vidyano.Service\Repository\UserSettingsActions.cs:448-449` — server signals satisfaction by queuing `ExecuteMethodOperation.ReloadPage()` once the gate is cleared.
 
-**Vidyano.Core silently discards `response["initial"]`** (`Vidyano.Core\Client.cs:394` reads `application`, `userName`, `userPicture`, `authToken`, and `session` from the GetApplication response — never `initial`). Every consumer — including `Vidyano.Script` — bypasses these gates.
+**Vidyano.Core silently discards `response["initial"]`** (`Vidyano.Core\Client.cs` reads `application`, `userName`, `userPicture`, `authToken`, and `session` from the GetApplication response — never `initial`). Every consumer — including `Vidyano.Script` — bypasses these gates.
+
+## How the gate is actually satisfied (v4 protocol)
+
+Verified against `P:\Vidyano\src`:
+
+- **`core/service.ts:1475-1477`** — on GetApplication, store `result.initial` as `service.initial`. No wait, no handshake, no listener.
+- **`web-components/sign-in/sign-in.ts:167-176`** — when `service.initial` is present, the sign-in component switches to an `"initial"` step and edits the PO.
+- **`web-components/sign-in/sign-in.ts:312-323`** — `_finishInitial`: `await this.initial.save();`, surface `notification` if present, then `this.service.clearInitial()` and navigate to the return URL. **No `reloadPage` wait, no GetApplication re-fetch.**
+
+The gate is therefore satisfied **the moment the SAVE on the Initial PO completes** (whether the response carries `reloadPage` or not). The auth-touching cases (password change, 2FA enable) rotate `authToken` *inline* in the SAVE response — Vidyano.Core's `PostAsync` already updates `AuthToken` from every response, so the client carries the new token forward automatically. `reloadPage` is only queued for Language / CultureInfo changes (`UserSettingsActions.cs:379,392`) and even then it flows through the existing `Hooks.OnClientOperation` channel — orthogonal to the gate.
 
 ## Constraints any design must satisfy
 
 1. Expose the Initial PO post-SignIn — observable by callers.
-2. **Not** auto-roundtripped on subsequent requests (unlike `Session`); it's a one-shot screen.
-3. Discovery without polling.
-4. Satisfaction protocol: server queues `ExecuteMethod` ClientOperation with `Name == "reloadPage"` when the gate is cleared → Vidyano.Core must offer a way to re-establish the session in response.
-5. Symmetry with `Client.Application` / `Client.Session`.
-6. Backwards-compat: callers that don't check `Initial` keep working (they bypass gates, with documented warning).
+2. Not auto-roundtripped on subsequent requests (unlike `Session`); the server only returns it from `GetApplication`.
+3. Caller can explicitly clear it after satisfying the gate (mirror v4's `service.clearInitial()`).
+4. Symmetry with `Client.Application` / `Client.Session`.
+5. Backwards-compat: callers that don't check `Initial` keep working (they bypass gates, with documented warning).
 
 ## Chosen interface
 
 ```csharp
 // Vidyano.Core\Client.cs — additions alongside Application / Session
-public PersistentObject Initial { get; private set; }   // observable; set during GetApplication, cleared after ReloadPage
-public Task EnsureInitialSatisfiedAsync(CancellationToken ct = default);
-public Task ReestablishSessionAsync(CancellationToken ct = default);
-
-// Vidyano.Core\Hooks.cs — one new hook (THE extension point)
-protected internal virtual Task OnInitialRequired(PersistentObject initial) => Task.CompletedTask;
+public PersistentObject Initial { get; private set; }   // observable; set during sign-in
+public void ClearInitial();                             // mirrors v4's service.clearInitial()
 ```
+
+That's it. Two members on `Client`. No new hook on `Hooks`.
 
 ### Behavior
 
-- **`Initial`** — set in `GetApplicationAsync` immediately after `Application = po;` from `response["initial"]` (null when omitted). `private set` + `SetProperty` so XAML/Avalonia bindings + `INotifyPropertyChanged` work. Cleared by `SignOut`.
-- **`EnsureInitialSatisfiedAsync(ct)`** — the common-case one-liner.
-  - If `Initial == null`: returns immediately.
-  - Otherwise: calls `Hooks.OnInitialRequired(Initial)`, awaits the returned `Task`, then waits internally for the server's `ReloadPage` ClientOperation, re-runs `GetApplication` under the existing `AuthToken`, and returns. `Initial` is `null` on return.
-- **`ReestablishSessionAsync(ct)`** — escape hatch for advanced callers that drove the Initial PO to SAVE themselves (multi-step wizard, custom flow). Performs only the re-run-GetApplication step. Idempotent.
-- **`Hooks.OnInitialRequired(po)`** — default no-op. Custom hosts override to render the PO; `Vidyano.Script` overrides to park the PO and complete when the script SAVEs the gate.
+- **`Initial`** — set in `SignInAsync` immediately after `Application = po;` from `response["initial"]`. Rejected when the PO carries an `Error`-type notification (mirroring `UpdateSession`'s guard against a smuggled `Vidyano.Error` PO). `null` when the server omits the field. `private set` + `SetProperty` so XAML / Avalonia bindings + `INotifyPropertyChanged` work. Also cleared by `SignOut`.
+- **`ClearInitial()`** — sets `Initial = null`. The 1:1 parallel of v4's `service.clearInitial()`. Idempotent; safe to call when `Initial` is already null. Use it after driving the gate PO to a successful `Save`.
 
-### Satisfaction handshake (concrete protocol)
-
-1. `GetApplicationAsync` reads `response["initial"]` → `Initial = Hooks.OnConstruct(this, json)`.
-2. Caller drives the PO (typically `Initial.Actions["Save"].Execute()`), either directly or via `EnsureInitialSatisfiedAsync` → `Hooks.OnInitialRequired`.
-3. Server action handler clears the gate and queues `ExecuteMethodOperation.ReloadPage()`.
-4. The operation flows through the existing `Hooks.OnClientOperation` pipeline. `EnsureInitialSatisfiedAsync` has an internal `TaskCompletionSource` listening for that op.
-5. On match: re-run `GetApplication` (preserves `AuthToken`), refresh `Application` / `Session` / `Messages` / `Actions`, null `Initial`, return.
-
-The handshake reuses two existing rails (PO action execution + `OnClientOperation`). No new wire protocol.
-
-### Usage
+The caller's loop is:
 
 ```csharp
-// 95% caller — custom .NET host / Vidyano.Script
-class ScriptHooks : Hooks
-{
-    protected override Task OnInitialRequired(PersistentObject po)
-        => scriptRunner.HandleAsync(po);   // saves the PO, or throws on strict
-}
-
 await client.SignInUsingCredentialsAsync(user, pwd);
-await client.EnsureInitialSatisfiedAsync();   // <-- the one line
-// From here on Application/Session are guaranteed gate-free.
-
-// Advanced caller — multi-step wizard drives Save itself
-await client.SignInUsingCredentialsAsync(user, pwd);
-if (client.Initial != null)
+if (client.Initial is { } gate)
 {
-    await myMultiStepWizard.Run(client.Initial);
-    await client.ReestablishSessionAsync();   // explicit re-handshake
+    await scriptRunner.HandleAsync(gate);   // drives the PO to Save
+    client.ClearInitial();
 }
+// From here on Application / Session are gate-free.
 ```
+
+An exception between `await` and `ClearInitial()` correctly skips the clear — the gate stays pending and the caller can retry or surface to the user. Wrapping this in a library helper hides nothing and would be a shallow module.
 
 ## Vidyano.Script follow-up (separate PR)
 
-Falls out cleanly from this design — sketched here for traceability, not in scope for the Vidyano.Core PR:
-
-- New `@initial` reserved variable, parallel to `@session`.
-- `VidyanoScriptHooks.OnInitialRequired(po)` parks `Client.Initial` as `@initial` and returns a `Task` that completes when the script SAVEs it (or errors out in strict mode).
+- New `@initial` reserved variable, parallel to `@session`, surfaces `Client.Initial`.
+- Script semantics: when `@initial` is present, the script SAVEs it like any other PO, then calls `client.ClearInitial()` via the runtime once the SAVE completes clean.
 - Until `@initial == null`, non-initial verbs error with `state-initial-pending`; escape via `@mode = direct`.
 
 ## Designs considered (and rejected)
 
-### Rejected — Minimal surface (one property, nothing else)
+### Rejected — `EnsureInitialSatisfiedAsync` with a `reloadPage` wait + `Hooks.OnInitialRequired` + `ReestablishSessionAsync` escape hatch
 
-Expose `Client.Initial` and stop. Each caller subscribes to `OnClientOperation`, filters for `ExecuteMethodOperation` with `Name == "reloadPage"`, re-calls `GetApplication`, handles re-entrancy.
+Initial implementation went down this path on the assumption that the server queues `ExecuteMethodOperation.ReloadPage()` to signal gate satisfaction, with `EnsureInitialSatisfiedAsync` blocking on that signal and then re-running GetApplication.
 
-**Why rejected:** punts the entire satisfaction protocol onto every consumer. The `ReloadPage` mechanism is one concrete protocol — Vidyano.Core should own it, not document it as a recipe. Inverts "pull complexity downwards."
+**Why rejected:** the assumption was wrong. The v4 sign-in component never waits for `reloadPage`; it treats the SAVE-success as the satisfaction signal and calls `service.clearInitial()` itself. The wait-for-`reloadPage` flow would have hung indefinitely on the common cases (accept-terms, 2FA enable, password reset — none of which queue `reloadPage`). Once that misconception is removed, the satisfaction protocol collapses to "caller calls `ClearInitial` after SAVE succeeds" and the entire `Ensure…` / `OnInitialRequired` / `Reestablish…` / polyfill / semaphore / internal-event stack is unnecessary plumbing for a problem the protocol doesn't have.
+
+### Rejected — `HandleInitialAsync(Func<PersistentObject, Task> handler)` helper
+
+Tempting wrapper: invoke the handler if `Initial != null`, then `ClearInitial()`; return `bool`.
+
+**Why rejected:** four lines that hide nothing. The caller's `if (client.Initial is { } po) { … ClearInitial(); }` form is just as short, makes the exception-skips-clear behaviour visible in code rather than hidden in XML doc, and avoids growing a shallow module. Caller-side control is the right default; if a clear cross-cutting pattern emerges later, the helper can be added without breaking anything.
 
 ### Rejected — Strategy pattern / maximize flexibility
 
-`IInitialStrategy` interface + `DefaultInitialStrategy` / `AutoSaveInitialStrategy` / `RequireExplicitInitialStrategy` + `InitialContext` (with `Disposition`/`Replacement`) + `InitialReloadMode` enum (4 modes) + 3 new hooks (`OnInitialReceiving`, `OnInitialReceived`, `OnInitialSatisfied`) + internal `InitialCoordinator`.
+`IInitialStrategy` + 3 strategy classes + `InitialContext` (with `Disposition`/`Replacement`) + `InitialReloadMode` enum + 3 new hooks + internal `InitialCoordinator`. ~12 surface types.
 
-**Why rejected:** ~12 surface types for two known consumer shapes (Vidyano.Script + custom host) that want essentially the same thing — "block until handled, then proceed." Premature framework-building; the 4×3 reload/disposition matrix solves problems we haven't seen and creates problems we will see.
-
-### Rejected — Common-case design, as originally drafted
-
-Same shape as the chosen design plus `AcknowledgeInitialBypass(reason)` (with a "warn on next mutation" side-channel through `OnException`) and `Hooks.OnInitialSatisfied()`.
-
-**Why partially rejected:** the bypass-warning channel is speculative and confuses errors with warnings; a caller who ignores `Client.Initial` chose to bypass — XML-doc the consequence. `OnInitialSatisfied` is redundant with `INotifyPropertyChanged` firing when `Initial` goes null. Both dropped from the chosen shape.
+**Why rejected:** premature framework-building for two known consumer shapes that want essentially the same thing.
 
 ## Tasks
 
-- [ ] `Client.cs` — add `Initial` property with `SetProperty`/private setter, parallel to `Session` (line ~162).
-- [ ] `Client.cs` `GetApplicationAsync` — set `Initial` from `response["initial"]` after `Application = po;` (line ~409).
-- [ ] `Client.cs` `SignOut` — null out `Initial` (line ~750).
-- [ ] `Client.cs` — implement `EnsureInitialSatisfiedAsync(CancellationToken)`: invokes `Hooks.OnInitialRequired(Initial)`, awaits, then waits for a `ReloadPage` `ExecuteMethodClientOperation` via internal `TaskCompletionSource`, re-runs `GetApplication` under existing `AuthToken`, returns.
-- [ ] `Client.cs` — implement `ReestablishSessionAsync(CancellationToken)` as the re-run-GetApplication portion of the above.
-- [ ] `Hooks.cs` — add `OnInitialRequired(PersistentObject) → Task` virtual hook with XML doc explaining the contract (return a Task that completes once the gate has been driven to Save / otherwise resolved).
-- [ ] XML doc on `Initial`: one-shot, not auto-roundtripped, casual callers bypass the gate if they ignore it.
-- [ ] Tests:
-  - Sign-in with no Initial → `Initial == null`, `EnsureInitialSatisfiedAsync` is a no-op.
-  - Sign-in with Initial → `Initial` non-null; `OnInitialRequired` fires; SAVE → `ReloadPage` → `Initial` cleared.
-  - `ReestablishSessionAsync` after caller-driven SAVE clears `Initial`.
-  - Cancellation token honoured during both the hook await and the `ReloadPage` wait.
+- [ ] `Client.cs` — add `Initial` property with `SetProperty`/private setter, parallel to `Session`.
+- [ ] `Client.cs` `SignInAsync` — set `Initial` from `response["initial"]` after `Application = po;`, rejecting `Vidyano.Error` / error-typed POs the way `UpdateSession` does for `Session`.
+- [ ] `Client.cs` `SignOut` — null `Initial` alongside the other client state.
+- [ ] `Client.cs` — add `ClearInitial()` public method.
+- [ ] XML doc on `Initial`: one-shot, not auto-roundtripped, casual callers bypass the gate if they ignore it; pointer to `ClearInitial`.
+- [ ] Tests (no test project in Vidyano.Core today; documented for manual verification):
+  - Sign-in with no Initial → `Initial == null`.
+  - Sign-in with Initial → `Initial` non-null; after handler + `ClearInitial()` → null.
+  - Sign-in with an Initial PO that has an Error-typed notification → throws.
   - `SignOut` clears `Initial`.
 
 ## Related


### PR DESCRIPTION
## Summary

- Exposes the server's **Initial PO** (`Advanced.OnLogin` gate — license terms, forced 2FA enrolment, forced password reset) on `Client`, which Vidyano.Core silently discarded today.
- Two members added to `Client`: `Initial` (observable, parallel to `Application` / `Session`) and `ClearInitial()` (mirrors v4's `service.clearInitial()`). No new hook on `Hooks`.
- Design doc at `docs/design/initial-po.md` records the v4 protocol findings and the rejected shapes.

## Protocol (verified against `P:\Vidyano\src`)

The v4 sign-in component treats the gate as satisfied **the moment `initial.save()` completes** — it surfaces any notification, then calls `service.clearInitial()` and navigates. No `reloadPage` wait, no GetApplication re-fetch. The auth-touching cases (password change, 2FA enable) rotate `authToken` inline in the SAVE response, and `PostAsync` already picks that up. `reloadPage` is only queued for Language / Culture changes and flows through the normal `OnClientOperation` channel — orthogonal to the gate.

## Why this matters

Apps that gate behind `Advanced.OnLogin` are bypassed entirely by every Vidyano.Core consumer today, including `Vidyano.Script`. This PR closes that gap with the minimum surface.

## Caller usage

```csharp
await client.SignInUsingCredentialsAsync(user, pwd);
if (client.Initial is { } gate)
{
    await scriptRunner.HandleAsync(gate);   // drives the PO to Save
    client.ClearInitial();
}
```

## Designs considered (and rejected)

- **`EnsureInitialSatisfiedAsync` with reloadPage wait + `Hooks.OnInitialRequired` + `ReestablishSessionAsync`** — the first cut. Built on the wrong assumption that the server signals satisfaction via `reloadPage`. Would have hung indefinitely on the common cases. Reverted after reading the v4 sign-in component.
- **`HandleInitialAsync(Func<PersistentObject, Task>)` helper** — a four-line wrapper that hides nothing. Shallow module; the raw `if/await/ClearInitial` form is just as short and makes the exception-skips-clear behaviour visible.
- **Strategy pattern (`IInitialStrategy` + 3 strategies + 3 hooks + coordinator)** — ~12 surface types for two known consumer shapes. Premature framework-building.

## Test plan

No test project exists in Vidyano.Core today; manually verify against `Test\Vidyano.Service.WebSampleRavenDB` (or similar) with a configured `Advanced.OnLogin`:
- [ ] Sign-in with no Initial → `Client.Initial == null`.
- [ ] Sign-in with Initial → `Client.Initial` non-null; after consumer's SAVE + `ClearInitial()` → `null`.
- [ ] Server returns a `Vidyano.Error` PO in the `initial` slot → `SignIn*Async` throws (mirroring `UpdateSession`).
- [ ] `SignOut` clears `Initial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)