### PR TITLE
feat: .visc detail-query addressing and GO-BACK navigation verb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,12 +122,15 @@ The repository also ships two scripting packages built on top of Vidyano.Core. T
 | `OPEN MenuItem <path>` | Push a Query frame on the nav stack. |
 | `OPEN-ROW <i>` | Push a PO frame from row `i` of the top Query (by index). |
 | `OPEN-ROW WHERE <col> = <value>` | Push a PO frame from the single row whose `<col>` equals `<value>` — addresses a fixture by reference, not index. Strict: 0 or >1 matches fail. Value is service-string form (same convention as `SET`); only `=` is supported. |
+| `OPEN-ROW Detail "<name>" <index\|WHERE …>` | Select the row from the named detail query on the current PO (`PersistentObject.Queries`) instead of the current Query. The `Detail` clause is orthogonal to the positional/`WHERE` choice. |
+| `GO-BACK` | Pop the top navigation frame, revealing the one beneath (the browser back button). Refuses when the top is a PO in edit (SAVE or CANCEL first) and when already at the root frame. |
 | `SEARCH <text>` | Text-search the current Query in place (no stack change). |
 | `EDIT` / `CANCEL` / `SAVE` | Standard PO edit lifecycle. SAVE pops + lets owner-driven refresh fire. |
 | `SET <attr> = <value>` | Change an attribute; reference SET resolves through lookup. |
 | `ACTION <action>` | Invoke an action by name. |
 | `EXPECT <state>` | Assert on `NavStack.*`, `TotalItems`, `IsInEdit`, `ClientOperation <type>`, attributes, notifications. Metadata forms: `Attribute X TYPE/TAG/TYPEHINT <k>`, `PO.<prop>` / `PO.Metadata.<k>` / `PO.NavigationHints.<k>`, `Query.<prop>` / `Query.Metadata.<k>` / `Query.NavigationHints.<k>` / `Query.PersistentObject.<prop>` / `Query.Columns[<name>].<prop>`. |
 | `TOOL <name> [k=v, …] [-> @var]` | Call a registered C# delegate. Named args only; throws become `tool-error` diagnostics. In-process: register on `VidyanoScriptOptions.Tools`. From the CLI: implement `IVidyanoScriptToolPack` in a DLL and pass `--tools <path.dll>`. |
+| `EXPECT Detail "<name>" <query-subject>` | Target a detail query on the current PO for query-family subjects (`TotalItems` / `Query.*`). Reads what the detail Query holds in memory (no forced search). |
 | `EXPECT <lhs> MATCHES "<regex>"` | Regex assertion on the subject's string form (1s ReDoS-guard timeout; null never matches). |
 | `REQUIRES <expect-subject> <op> <value>` | Precondition gate reusing the full EXPECT grammar. Holds → pass + continue. Unmet/unevaluable → skip the rest of the body (`state-requires-unmet`, not a failure). |
 | `REQUIRES TOOL <name>` | Capability gate; skips the body unless a tool of that name is registered. |

--- a/Vidyano.Script.Tests/DetailQueryAndGoBackLintTests.cs
+++ b/Vidyano.Script.Tests/DetailQueryAndGoBackLintTests.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using Vidyano.Script;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Parser/grammar coverage for three new <c>.visc</c> additions: the zero-arg <c>GO-BACK</c> verb,
+/// the optional <c>Detail "&lt;name&gt;"</c> clause on <c>OPEN-ROW</c>, and the optional
+/// <c>Detail "&lt;name&gt;"</c> prefix on <c>EXPECT</c> (which must be followed by a query-family
+/// subject). These tests never touch a server: they assert what <see cref="VidyanoScript.Lint"/>
+/// accepts (zero diagnostics) or rejects (a diagnostic).
+/// </summary>
+public sealed class DetailQueryAndGoBackLintTests
+{
+    private static void AssertClean(string body)
+    {
+        var diags = VidyanoScript.Lint(body);
+        Assert.True(diags.Count == 0,
+            $"Expected no diagnostics, got: {string.Join("; ", diags.Select(d => $"{d.Kind}: {d.Message}"))}");
+    }
+
+    private static void AssertHasDiagnostic(string body)
+    {
+        var diags = VidyanoScript.Lint(body);
+        Assert.True(diags.Count > 0, "Expected at least one parse diagnostic, got none.");
+    }
+
+    // --- GO-BACK (zero-arg verb) --------------------------------------------------------------
+
+    [Fact]
+    public void GoBack_Parses()
+    {
+        AssertClean("GO-BACK");
+    }
+
+    [Fact]
+    public void GoBack_LowerCase_Parses()
+    {
+        AssertClean("go-back");
+    }
+
+    // --- OPEN-ROW Detail "<name>" <selector> --------------------------------------------------
+
+    [Fact]
+    public void OpenRowDetail_StringNameWithIndex_Parses()
+    {
+        AssertClean("OPEN-ROW Detail \"OrderLines\" 0");
+    }
+
+    [Fact]
+    public void OpenRowDetail_BareIdentifierName_Parses()
+    {
+        AssertClean("OPEN-ROW Detail OrderLines 0");
+    }
+
+    [Fact]
+    public void OpenRowDetail_IndexWithAsHandle_Parses()
+    {
+        AssertClean("OPEN-ROW Detail \"OrderLines\" 0 AS @line");
+    }
+
+    [Fact]
+    public void OpenRowDetail_Where_Parses()
+    {
+        AssertClean("OPEN-ROW Detail \"OrderLines\" WHERE Product = \"Widget\"");
+    }
+
+    [Fact]
+    public void OpenRowDetail_WhereWithAsHandle_Parses()
+    {
+        AssertClean("OPEN-ROW Detail \"OrderLines\" WHERE Sku = \"A1\" AS @line");
+    }
+
+    [Fact]
+    public void OpenRowDetail_CaseInsensitiveKeyword_Parses()
+    {
+        AssertClean("OPEN-ROW detail \"OrderLines\" 0");
+    }
+
+    [Fact]
+    public void OpenRowDetail_MissingNameAndSelector_Diagnoses()
+    {
+        AssertHasDiagnostic("OPEN-ROW Detail");
+    }
+
+    [Fact]
+    public void OpenRowDetail_MissingSelector_Diagnoses()
+    {
+        AssertHasDiagnostic("OPEN-ROW Detail \"OrderLines\"");
+    }
+
+    [Fact]
+    public void OpenRowDetail_WhereNonEqualsOperator_Diagnoses()
+    {
+        AssertHasDiagnostic("OPEN-ROW Detail \"OrderLines\" WHERE Sku CONTAINS \"A1\"");
+    }
+
+    // --- OPEN-ROW pre-existing forms still parse (regression) ---------------------------------
+
+    [Fact]
+    public void OpenRow_Positional_StillParses()
+    {
+        AssertClean("OPEN-ROW 0");
+    }
+
+    [Fact]
+    public void OpenRow_Where_StillParses()
+    {
+        AssertClean("OPEN-ROW WHERE Name = \"Acme\"");
+    }
+
+    // --- EXPECT Detail "<name>" <query-subject> -----------------------------------------------
+
+    [Fact]
+    public void ExpectDetail_TotalItemsEquals_Parses()
+    {
+        AssertClean("EXPECT Detail \"OrderLines\" TotalItems = 3");
+    }
+
+    [Fact]
+    public void ExpectDetail_TotalItemsGreaterOrEqual_Parses()
+    {
+        AssertClean("EXPECT Detail \"OrderLines\" TotalItems >= 1");
+    }
+
+    [Fact]
+    public void ExpectDetail_BareIdentifierName_Parses()
+    {
+        AssertClean("EXPECT Detail OrderLines TotalItems = 3");
+    }
+
+    [Fact]
+    public void ExpectDetail_QueryHasSearched_Parses()
+    {
+        AssertClean("EXPECT Detail \"OrderLines\" Query.HasSearched = true");
+    }
+
+    [Fact]
+    public void ExpectDetail_QueryColumnLabel_Parses()
+    {
+        AssertClean("EXPECT Detail \"OrderLines\" Query.Columns[Sku].Label = \"SKU\"");
+    }
+
+    [Fact]
+    public void ExpectDetail_NonQueryBareAttribute_Diagnoses()
+    {
+        AssertHasDiagnostic("EXPECT Detail \"OrderLines\" Status = \"Approved\"");
+    }
+
+    [Fact]
+    public void ExpectDetail_NonQueryIsInEdit_Diagnoses()
+    {
+        AssertHasDiagnostic("EXPECT Detail \"OrderLines\" IsInEdit = true");
+    }
+
+    [Fact]
+    public void ExpectDetail_MissingName_Diagnoses()
+    {
+        AssertHasDiagnostic("EXPECT Detail");
+    }
+
+    [Fact]
+    public void ExpectDetail_NestedDetail_Diagnoses()
+    {
+        AssertHasDiagnostic("EXPECT Detail \"X\" Detail \"Y\" TotalItems = 1");
+    }
+}

--- a/Vidyano.Script.Tool/VerbReference.cs
+++ b/Vidyano.Script.Tool/VerbReference.cs
@@ -27,6 +27,8 @@ public static class VerbReference
         t.AddRow("OPEN MenuItem",        "OPEN MenuItem Sales/Customers",       "Walks the user's menu (Application.Queries[[ProgramUnits]]).");
         t.AddRow("OPEN-ROW",             "OPEN-ROW 0 AS @row",                  "Opens the PO behind a row of the current query, by index.");
         t.AddRow("OPEN-ROW WHERE",       "OPEN-ROW WHERE Name = \"Acme\"",       "Opens the PO behind the single row whose column equals the value. Strict: 0 or >1 matches fail. Value is service-string form, like SET.");
+        t.AddRow("OPEN-ROW Detail",      "OPEN-ROW Detail \"OrderLines\" 0",     "Selects the row from a detail query (PO.Queries[[name]]) instead of the current query. Works with the index or WHERE form.");
+        t.AddRow("GO-BACK",              "GO-BACK",                             "Pops the top nav frame (browser back). Refuses on a PO in edit, or at the root frame.");
         t.AddRow("SEARCH",               "SEARCH \"Acme\"",                      "Searches the current query.");
         t.AddRow("EDIT",                 "EDIT",                                "Enters edit mode on the current PO. SET auto-enters.");
         t.AddRow("SET",                  "SET Name = \"Acme Corp\"",             "For reference attrs the runner auto-picks via Options/Lookup.");
@@ -45,6 +47,7 @@ public static class VerbReference
         t.AddRow("EXPECT Attr TYPE",     "EXPECT Attribute X TYPE = \"String\"",  "Or TAG / TYPEHINT key for round-tripped metadata.");
         t.AddRow("EXPECT PO.<prop>",     "EXPECT PO.Type = \"Customer\"",         "Plus PO.Tag / PO.Metadata.<k> / PO.NavigationHints.<k>.");
         t.AddRow("EXPECT Query.<prop>",  "EXPECT Query.Columns[[Name]].Label = …", "Plus Query.Metadata.<k>, Query.PersistentObject.Type, etc.");
+        t.AddRow("EXPECT Detail …",      "EXPECT Detail \"OrderLines\" TotalItems = 3", "Targets a detail query on the current PO. Only query subjects (TotalItems / Query.*).");
         t.AddRow("TOOL",                 "TOOL fetch-user id=42 -> @user",      "Registered handler. CLI: load via --tools <pack.dll> (IVidyanoScriptToolPack).");
         t.AddRow("EXPECT … MATCHES",     "EXPECT Code MATCHES \"^[[A-Z]]{2}\\\\d+$\"", "Regex assertion (1s ReDoS-guard timeout). Null never matches.");
         t.AddRow("REQUIRES",             "REQUIRES TotalItems >= 1",            "Precondition gate (reuses EXPECT grammar). Unmet → skip rest of body.");

--- a/Vidyano.Script/Diagnostics/ErrorKind.cs
+++ b/Vidyano.Script/Diagnostics/ErrorKind.cs
@@ -42,6 +42,7 @@ public static class ErrorKind
     public const string GuardRequiredMissing     = "guard-required-missing";
     public const string GuardEditModeRequired    = "guard-edit-mode-required";
     public const string GuardNotInEdit           = "guard-not-in-edit";
+    public const string GuardInEdit              = "guard-in-edit";
 
     // Tier-2 guard — reachability (used in `navigation` mode)
     public const string GuardNotReachable        = "guard-not-reachable";
@@ -55,6 +56,7 @@ public static class ErrorKind
     public const string StateScopeNotImplemented = "state-scope-not-implemented";
     public const string StateInitialPending      = "state-initial-pending";
     public const string StateHandleStale         = "state-handle-stale";
+    public const string StateNavStackAtRoot      = "state-nav-stack-at-root";
     /// <summary>Informational: a <c>REQUIRES</c> precondition was not met (or could not be
     /// evaluated), so the rest of the body is skipped. Not a failure.</summary>
     public const string StateRequiresUnmet       = "state-requires-unmet";

--- a/Vidyano.Script/Parsing/Ast.cs
+++ b/Vidyano.Script/Parsing/Ast.cs
@@ -54,8 +54,16 @@ public sealed record OpenMenuItemStmt(IReadOnlyList<Expression> PathSegments, st
 /// fields null); the by-value form sets <see cref="MatchColumn"/> + <see cref="MatchOp"/> +
 /// <see cref="MatchValue"/> (with <see cref="Index"/> null). <see cref="MatchOp"/> is modelled with the
 /// EXPECT operator enum so a future operator is a parser whitelist change; only <see cref="ExpectOp.Eq"/>
-/// is accepted in this build.</summary>
-public sealed record OpenRowStmt(Expression? Index, string? AsHandle, SourceLocation Location, string? MatchColumn = null, ExpectOp? MatchOp = null, Expression? MatchValue = null) : Statement(Location);
+/// is accepted in this build.
+/// <para><see cref="DetailName"/> (the optional <c>Detail "&lt;name&gt;"</c> clause) is orthogonal to the
+/// positional-vs-WHERE choice: when set, the row is selected from the named detail query on the current
+/// PO (<see cref="PersistentObject.Queries"/>) instead of the current Query.</para></summary>
+public sealed record OpenRowStmt(Expression? Index, string? AsHandle, SourceLocation Location, string? MatchColumn = null, ExpectOp? MatchOp = null, Expression? MatchValue = null, string? DetailName = null) : Statement(Location);
+
+/// <summary><c>GO-BACK</c> — pop the top navigation frame, revealing the one beneath (the
+/// browser back button). Refuses when the top is a PO in edit (SAVE or CANCEL first) and when
+/// already at the root frame.</summary>
+public sealed record GoBackStmt(SourceLocation Location) : Statement(Location);
 
 /// <summary><c>EDIT</c> — enter edit mode on the current PO.</summary>
 public sealed record EditStmt(string? Handle, SourceLocation Location) : Statement(Location);
@@ -198,8 +206,11 @@ public enum ExpectSubjectKind
 /// <see cref="ExpectSubjectKind.Expression"/> (interpolation-as-subject). <see cref="Scope"/> is the
 /// reserved variable scope (<c>"session"</c>) when the subject is <c>@session.X</c>; <c>null</c>
 /// means the top of the navigation stack. <see cref="MetadataKey"/> carries the bag key for
-/// metadata / navigation-hint / typehint forms, and the leaf-property name for column lookups.</summary>
-public sealed record ExpectSubject(ExpectSubjectKind Kind, string? Name, AttributeFlagKind Flag, SourceLocation Location, Expression? Lhs = null, string? Scope = null, string? MetadataKey = null);
+/// metadata / navigation-hint / typehint forms, and the leaf-property name for column lookups.
+/// <see cref="DetailName"/> is set by the <c>EXPECT Detail "&lt;name&gt;" &lt;query-subject&gt;</c> form: when
+/// non-null, query-family subjects resolve against <c>CurrentPo.Queries[DetailName]</c> instead of the
+/// current-query walk.</summary>
+public sealed record ExpectSubject(ExpectSubjectKind Kind, string? Name, AttributeFlagKind Flag, SourceLocation Location, Expression? Lhs = null, string? Scope = null, string? MetadataKey = null, string? DetailName = null);
 
 /// <summary>Which boolean attribute property an <c>EXPECT Attribute X IS ...</c> targets.</summary>
 public enum AttributeFlagKind { None, Visible, ReadOnly, Required }

--- a/Vidyano.Script/Parsing/Parser.cs
+++ b/Vidyano.Script/Parsing/Parser.cs
@@ -19,7 +19,7 @@ public sealed class Parser
 
     private static readonly HashSet<string> KnownVerbs = new(StringComparer.OrdinalIgnoreCase)
     {
-        "SIGN-IN", "SIGN-OUT", "USE", "OPEN", "OPEN-ROW", "FOLLOW", "OPEN-DETAIL",
+        "SIGN-IN", "SIGN-OUT", "USE", "OPEN", "OPEN-ROW", "GO-BACK", "FOLLOW", "OPEN-DETAIL",
         "EDIT", "CANCEL", "SAVE", "REFRESH", "RELOAD",
         "SET", "ACTION", "SEARCH", "SELECT-ROWS",
         "EXPECT", "GOTO",
@@ -133,6 +133,7 @@ public sealed class Parser
             "USE"         => ParseUse(tok.Location),
             "OPEN"        => ParseOpen(tok.Location),
             "OPEN-ROW"    => ParseOpenRow(tok.Location),
+            "GO-BACK"     => new GoBackStmt(tok.Location),
             "EDIT"        => new EditStmt(null, tok.Location),
             "CANCEL"      => new CancelStmt(null, tok.Location),
             "SAVE"        => ParseSave(tok.Location),
@@ -347,6 +348,16 @@ public sealed class Parser
 
     private Statement? ParseOpenRow(SourceLocation loc)
     {
+        // Optional leading `Detail "<name>"` clause: selects the row from the named detail query on the
+        // current PO instead of the current Query. Orthogonal to the WHERE/positional choice below.
+        string? detailName = null;
+        if (Peek().Kind == TokenKind.Identifier && string.Equals(Peek().Lexeme, "Detail", StringComparison.OrdinalIgnoreCase))
+        {
+            Advance();
+            detailName = ParseDetailName();
+            if (detailName == null) return null;
+        }
+
         // Contextual keyword: `WHERE` right after OPEN-ROW selects the by-value form. Anything else
         // is parsed as the positional index expression, exactly as before.
         if (Peek().Kind == TokenKind.Identifier &&
@@ -370,13 +381,25 @@ public sealed class Parser
             var value = ParseValueExpression();
             if (value == null) return null;
             var whereHandle = ParseOptionalAs();
-            return new OpenRowStmt(null, whereHandle, loc, MatchColumn: column, MatchOp: ExpectOp.Eq, MatchValue: value);
+            return new OpenRowStmt(null, whereHandle, loc, MatchColumn: column, MatchOp: ExpectOp.Eq, MatchValue: value, DetailName: detailName);
         }
 
         var index = ParseValueExpression();
         if (index == null) return null;
         var asHandle = ParseOptionalAs();
-        return new OpenRowStmt(index, asHandle, loc);
+        return new OpenRowStmt(index, asHandle, loc, DetailName: detailName);
+    }
+
+    /// <summary>Parses a detail-query name after the <c>Detail</c> keyword: a string literal or a bare
+    /// identifier. Names are static schema identifiers, so (unlike values) they are not expressions.</summary>
+    private string? ParseDetailName()
+    {
+        var t = Peek();
+        if (t.Kind == TokenKind.String) { Advance(); return t.Value as string ?? t.Lexeme; }
+        if (t.Kind == TokenKind.Identifier) { Advance(); return t.Lexeme; }
+        Error(ErrorKind.ParseExpected, "Expected a detail-query name after 'Detail'.", t.Location,
+            hint: "OPEN-ROW Detail \"OrderLines\" 0");
+        return null;
     }
 
     // --- SET / ACTION / SEARCH ----------------------------------------------------------------
@@ -694,9 +717,38 @@ public sealed class Parser
         return (subject, cmp, rhs);
     }
 
+    private static bool IsQueryFamilySubject(ExpectSubjectKind k) => k is
+        ExpectSubjectKind.TotalItems or ExpectSubjectKind.QueryProperty or ExpectSubjectKind.QueryLabel or
+        ExpectSubjectKind.QueryMetadata or ExpectSubjectKind.QueryNavigationHints or
+        ExpectSubjectKind.QueryPoProperty or ExpectSubjectKind.QueryColumn;
+
     private ExpectSubject? ParseExpectSubject()
     {
         var tok = Peek();
+
+        // EXPECT Detail "<name>" <query-subject> — redirect query-family subjects to a detail query
+        // on the current PO. Recurses to parse the inner subject and stamps the detail name onto it.
+        if (tok.Kind == TokenKind.Identifier && string.Equals(tok.Lexeme, "Detail", StringComparison.OrdinalIgnoreCase))
+        {
+            Advance();
+            var detailName = ParseDetailName();
+            if (detailName == null) return null;
+            var inner = ParseExpectSubject();
+            if (inner == null) return null;
+            if (inner.DetailName != null)
+            {
+                Error(ErrorKind.ParseUnexpectedToken, "Nested 'Detail' is not allowed.", tok.Location);
+                return null;
+            }
+            if (!IsQueryFamilySubject(inner.Kind))
+            {
+                Error(ErrorKind.ParseUnexpectedToken,
+                    "EXPECT Detail can only target query subjects (TotalItems or Query.*).", tok.Location,
+                    hint: "EXPECT Detail \"OrderLines\" TotalItems = 3");
+                return null;
+            }
+            return inner with { DetailName = detailName };
+        }
 
         // EXPECT {{expr}} ... — variable or {{Messages.X}} lookup on the LHS.
         if (tok.Kind == TokenKind.Interp)

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -161,6 +161,7 @@ public sealed class Interpreter
             case OpenQueryStmt oq:             return await DoOpenQuery(oq).ConfigureAwait(false);
             case OpenMenuItemStmt om:          return await DoOpenMenu(om).ConfigureAwait(false);
             case OpenRowStmt or:               return await DoOpenRow(or).ConfigureAwait(false);
+            case GoBackStmt gb:                return Wrap(stmt, _session.GoBack(gb.Location));
             case EditStmt e:                   return Wrap(stmt, _session.Edit(e.Location));
             case CancelStmt c:                 return Wrap(stmt, _session.Cancel(c.Location));
             case SaveStmt sv:
@@ -261,7 +262,7 @@ public sealed class Interpreter
         {
             var mv = EvaluateExpression(or.MatchValue!);
             if (!mv.Ok) return Fail(or, mv.Error!);
-            var whereRes = await _session.OpenRowWhereAsync(or.MatchColumn, mv.Value, or.AsHandle, or.Location).ConfigureAwait(false);
+            var whereRes = await _session.OpenRowWhereAsync(or.MatchColumn, mv.Value, or.AsHandle, or.Location, or.DetailName).ConfigureAwait(false);
             return Wrap(or, whereRes);
         }
 
@@ -269,7 +270,7 @@ public sealed class Interpreter
         if (!v.Ok) return Fail(or, v.Error!);
         if (!TryCoerceInt(v.Value, out var index))
             return Fail(or, new Diagnostic(ErrorKind.ParseInvalidValue, "OPEN-ROW needs an integer index.", or.Location));
-        var res = await _session.OpenRowAsync(index, or.AsHandle, or.Location).ConfigureAwait(false);
+        var res = await _session.OpenRowAsync(index, or.AsHandle, or.Location, or.DetailName).ConfigureAwait(false);
         return Wrap(or, res);
     }
 
@@ -572,6 +573,16 @@ public sealed class Interpreter
     {
         var po = _session.CurrentPo;
         var query = _session.CurrentQuery;
+
+        // EXPECT Detail "<name>" <query-subject>: reroute all query-family subjects to the named detail
+        // query on the current PO. Read whatever the detail Query has in memory (no forced search) —
+        // identical to the current-query EXPECT TotalItems contract.
+        if (subj.DetailName is not null)
+        {
+            var detail = _session.ResolveDetail(subj.DetailName, loc);
+            if (!detail.Ok) return Fail<object?>(detail.Error!);
+            query = detail.Value;
+        }
 
         switch (subj.Kind)
         {

--- a/Vidyano.Script/Runtime/VidyanoSession.cs
+++ b/Vidyano.Script/Runtime/VidyanoSession.cs
@@ -405,18 +405,44 @@ public sealed class VidyanoSession : IDisposable
         }
     }
 
-    public async Task<OpResult> OpenRowAsync(int index, string? asHandle, SourceLocation loc)
+    /// <summary>Resolves a detail query by name on the current PO (<see cref="PersistentObject.Queries"/>).
+    /// Surfaces a suggester hint on a missing name.</summary>
+    public OpResult<Query> ResolveDetail(string name, SourceLocation loc)
     {
+        if (CurrentPo is null)
+            return OpResult<Query>.Fail(new Diagnostic(ErrorKind.StateNoCurrentPo,
+                "Detail needs a current PersistentObject.", loc));
+        if (!CurrentPo.Queries.TryGetValue(name, out var q))
+            return OpResult<Query>.Fail(new Diagnostic(ErrorKind.ResolveQuery,
+                $"PersistentObject '{CurrentPo.Type}' has no detail query '{name}'.", loc,
+                Hint: Suggester.Hint(name, CurrentPo.Queries.Keys)));
+        return OpResult<Query>.Success(q);
+    }
+
+    /// <summary>Resolves the Query an OPEN-ROW targets: the named detail query on the current PO when
+    /// <paramref name="detailName"/> is set, otherwise the current Query. Keeps both OPEN-ROW bodies
+    /// agnostic to which query they're scanning.</summary>
+    private OpResult<Query> ResolveRowQuery(string? detailName, SourceLocation loc)
+    {
+        if (detailName is not null) return ResolveDetail(detailName, loc);
         if (CurrentQuery is null)
-            return OpResult.Fail(new Diagnostic(ErrorKind.StateNoCurrentQuery, "OPEN-ROW needs a current Query.", loc));
-        if (index < 0 || index >= CurrentQuery.TotalItems)
+            return OpResult<Query>.Fail(new Diagnostic(ErrorKind.StateNoCurrentQuery, "OPEN-ROW needs a current Query.", loc));
+        return OpResult<Query>.Success(CurrentQuery);
+    }
+
+    public async Task<OpResult> OpenRowAsync(int index, string? asHandle, SourceLocation loc, string? detailName = null)
+    {
+        var qt = ResolveRowQuery(detailName, loc);
+        if (!qt.Ok) return OpResult.Fail(qt.Error!);
+        var query = qt.Value!;
+        if (index < 0 || index >= query.TotalItems)
             return OpResult.Fail(new Diagnostic(
                 ErrorKind.AssertFailed,
-                $"Row index {index} is out of range (Query has {CurrentQuery.TotalItems} items).",
+                $"Row index {index} is out of range (Query has {query.TotalItems} items).",
                 loc));
         try
         {
-            var items = await CurrentQuery.GetItemsAsync(index, 1).ConfigureAwait(false);
+            var items = await query.GetItemsAsync(index, 1).ConfigureAwait(false);
             var row = items.FirstOrDefault();
             if (row is null)
                 return OpResult.Fail(new Diagnostic(ErrorKind.ServerError, $"Could not load row {index}.", loc));
@@ -433,17 +459,18 @@ public sealed class VidyanoSession : IDisposable
     /// strict: zero matches or more than one match are assertion failures (no first-wins), so a row picked
     /// this way is unambiguous. The full result set is loaded and filtered exactly client-side; the
     /// underlying Query's search state is left untouched.</summary>
-    public async Task<OpResult> OpenRowWhereAsync(string column, object? value, string? asHandle, SourceLocation loc)
+    public async Task<OpResult> OpenRowWhereAsync(string column, object? value, string? asHandle, SourceLocation loc, string? detailName = null)
     {
-        if (CurrentQuery is null)
-            return OpResult.Fail(new Diagnostic(ErrorKind.StateNoCurrentQuery, "OPEN-ROW needs a current Query.", loc));
+        var qt = ResolveRowQuery(detailName, loc);
+        if (!qt.Ok) return OpResult.Fail(qt.Error!);
+        var query = qt.Value!;
 
-        var columnNames = CurrentQuery.Columns.Select(c => c.Name).ToArray();
+        var columnNames = query.Columns.Select(c => c.Name).ToArray();
         var matchedColumn = columnNames.FirstOrDefault(n => string.Equals(n, column, StringComparison.OrdinalIgnoreCase));
         if (matchedColumn is null)
             return OpResult.Fail(new Diagnostic(
                 ErrorKind.ResolveAttribute,
-                $"Column '{column}' does not exist on Query '{CurrentQuery.Name}'.",
+                $"Column '{column}' does not exist on Query '{query.Name}'.",
                 loc,
                 Hint: Suggester.Hint(column, columnNames)));
 
@@ -456,9 +483,10 @@ public sealed class VidyanoSession : IDisposable
         try
         {
             // top==0 = all rows from skip — load the whole set and filter exactly client-side. We do
-            // NOT SearchTextAsync to narrow: that mutates the underlying Query's search state, which
-            // would linger after this row's PO frame pops (CurrentQuery returns the same instance).
-            var items = await CurrentQuery.GetItemsAsync(0, 0).ConfigureAwait(false);
+            // NOT SearchTextAsync to narrow: that mutates the resolved Query's search state, which
+            // would linger after this row's PO frame pops. The resolved instance is retained either on
+            // the nav stack (CurrentQuery path) or on the parent PO's Queries dictionary (Detail path).
+            var items = await query.GetItemsAsync(0, 0).ConfigureAwait(false);
             var matches = items
                 .Where(r => r != null &&
                             string.Equals(Vidyano.Client.ToServiceString(r[matchedColumn]), target, StringComparison.Ordinal))
@@ -467,7 +495,7 @@ public sealed class VidyanoSession : IDisposable
             if (matches.Count == 0)
                 return OpResult.Fail(new Diagnostic(
                     ErrorKind.AssertFailed,
-                    $"No row where {matchedColumn} = \"{target}\" (Query '{CurrentQuery.Name}' has {CurrentQuery.TotalItems} items).",
+                    $"No row where {matchedColumn} = \"{target}\" (Query '{query.Name}' has {query.TotalItems} items).",
                     loc));
             if (matches.Count > 1)
                 return OpResult.Fail(new Diagnostic(
@@ -502,6 +530,18 @@ public sealed class VidyanoSession : IDisposable
     {
         if (CurrentPo is null) return NoCurrentPo(loc);
         CurrentPo.Edit();
+        return OpResult.Success;
+    }
+
+    public OpResult GoBack(SourceLocation loc)
+    {
+        if (_navStack.Count < 2)
+            return OpResult.Fail(new Diagnostic(ErrorKind.StateNavStackAtRoot,
+                "GO-BACK has nowhere to go — already at the root frame.", loc));
+        if (_navStack[^1] is PoEntry { Po.IsInEdit: true })
+            return OpResult.Fail(new Diagnostic(ErrorKind.GuardInEdit,
+                "GO-BACK can't leave a PO with unsaved edits — SAVE or CANCEL first.", loc));
+        _navStack.RemoveAt(_navStack.Count - 1);
         return OpResult.Success;
     }
 


### PR DESCRIPTION
Adds three coordinated additions to the `.visc` engine so scripts can reach a `PersistentObject`'s detail queries (`CurrentPo.Queries[name]`) without breaking the existing downward `CurrentQuery` walk.

## What's new

### 1. `GO-BACK` — general navigation-back verb
Pops the top `NavEntry` of any kind (queries *and* non-edit POs), modelling the browser back button. Fills a real gap: previously only edit-driven `SAVE`/`CANCEL` could pop a frame, and nothing could pop a `QueryEntry` at all.

Guards:
- In-edit PO → refuse with new `GuardInEdit` ("SAVE or CANCEL first" — never silently discards edits).
- Root frame (depth < 2) → refuse with new `StateNavStackAtRoot`.

### 2. `OPEN-ROW Detail "<name>" <index|WHERE col=val>`
Opens a row from a named detail query of the current PO. Pushes the detail row's PO as a regular `PoEntry` frame, poppable via `SAVE`/`CANCEL`/`GO-BACK` back to the parent PO. Both positional and `WHERE` selectors compose with `Detail`.

### 3. `EXPECT Detail "<name>" <query-subject>`
Rebinds the EXPECT target query from the downward walk to `CurrentPo.Queries[name]`, reusing the entire `Query.*` / `TotalItems` / `Columns[…]` evaluator. **Frame-free** — no stack mutation, no forced server search.

```visc
OPEN MenuItem Sales/Orders
OPEN-ROW WHERE Number = "ORD-1001"          # PoEntry(Order)
EXPECT Detail "OrderLines" TotalItems = 3   # frame-free read
OPEN-ROW Detail "OrderLines" WHERE Sku = "A1"
EDIT
SET Quantity = 5
SAVE                                         # back on the Order
GO-BACK                                      # back on the Orders list
```

## Design

Both verbs route through a shared `VidyanoSession.ResolveDetail` resolver, so the missing-name diagnostic + `Suggester.Hint` over `CurrentPo.Queries.Keys` are identical across forms. The OpenRow methods were refactored to resolve a target `Query` up front via a private `ResolveRowQuery`, leaving the positional / WHERE bodies untouched.

Detail names are parsed as string-literal-or-identifier (a plain `string`, not an `Expression`) — matches how column/attribute names are parsed; no `{{interp}}` for detail names in v1.

A tidier `OPEN Detail` that pushes the detail query as a `QueryEntry` frame was considered and **deferred** to a phase 2 that would ship it alongside richer `GO-BACK` semantics for orphaned query frames. `OPEN-ROW Detail … WHERE` already covers most of what `OPEN Detail` + `SEARCH` would enable.

## Coverage

- 22 new lint tests in `Vidyano.Script.Tests` covering parser/grammar (no backend required).
- Full suite: **80 passed, 0 failed, 0 skipped** (22 new + 58 pre-existing, zero regressions).
- Build green across netstandard2.0 / net8.0 / net10.0, 0 warnings.
- `VerbReference.cs` (`help verbs` table) and the `CLAUDE.md` `.visc` quick reference updated in lockstep.

## Files changed

| File | Change |
|---|---|
| `Vidyano.Script/Parsing/Ast.cs` | New `GoBackStmt`; `OpenRowStmt` and `ExpectSubject` gain optional `DetailName`. |
| `Vidyano.Script/Parsing/Parser.cs` | `GO-BACK` in `KnownVerbs` + dispatch; `ParseDetailName` helper; `Detail` clause on `ParseOpenRow` + `ParseExpectSubject` with `IsQueryFamilySubject` guard. |
| `Vidyano.Script/Diagnostics/ErrorKind.cs` | New `GuardInEdit`, `StateNavStackAtRoot` consts. |
| `Vidyano.Script/Runtime/VidyanoSession.cs` | `ResolveDetail`, `ResolveRowQuery`, `GoBack`; OpenRow* refactored to operate on a resolved target. |
| `Vidyano.Script/Runtime/Interpreter.cs` | `GoBackStmt` dispatch; EXPECT subject `DetailName` redirect. |
| `Vidyano.Script.Tool/VerbReference.cs` | Three new help rows. |
| `Vidyano.Script.Tests/DetailQueryAndGoBackLintTests.cs` | New — 22 grammar tests. |
| `CLAUDE.md` | `.visc` quick-reference table updated. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)