### PR TITLE
feat: .visc Language Server Protocol support for editors

### DIFF
--- a/Vidyano.Core.sln
+++ b/Vidyano.Core.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vidyano.Script.Tool", "Vidy
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vidyano.Script.Tests", "Vidyano.Script.Tests\Vidyano.Script.Tests.csproj", "{C72EE8BF-50B4-435B-B5AE-63E301F76C92}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vidyano.Script.LanguageServer", "Vidyano.Script.LanguageServer\Vidyano.Script.LanguageServer.csproj", "{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{C72EE8BF-50B4-435B-B5AE-63E301F76C92}.Release|x64.Build.0 = Release|Any CPU
 		{C72EE8BF-50B4-435B-B5AE-63E301F76C92}.Release|x86.ActiveCfg = Release|Any CPU
 		{C72EE8BF-50B4-435B-B5AE-63E301F76C92}.Release|x86.Build.0 = Release|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Release|x64.Build.0 = Release|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1F9A2C4-3D6E-4F8A-9B2C-7E1D5A4C8F30}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Vidyano.Script.LanguageServer/DiagnosticMapper.cs
+++ b/Vidyano.Script.LanguageServer/DiagnosticMapper.cs
@@ -1,0 +1,31 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Vidyano.Script.Diagnostics;
+using EngineDiagnostic = Vidyano.Script.Diagnostics.Diagnostic;
+using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
+
+namespace Vidyano.Script.LanguageServer;
+
+/// <summary>
+/// Pure value transform: an engine <see cref="EngineDiagnostic"/> becomes the LSP wire shape. Severity
+/// is derived from the diagnostic's <c>Kind</c> string prefix, and the point location is widened into a
+/// <see cref="Range"/> over the offending word.
+/// </summary>
+internal static class DiagnosticMapper
+{
+    public static LspDiagnostic ToLsp(EngineDiagnostic d, string text) => new()
+    {
+        Range = ViscLanguageService.RangeAt(d.Location, text),
+        Severity = SeverityFor(d.Kind),
+        Code = d.Kind,
+        Source = "visc",
+        Message = d.Hint is null ? d.Message : $"{d.Message} {d.Hint}",
+    };
+
+    // v1 never executes a script, so only lexer/parser kinds reach the editor — every one of those is an
+    // error. The `lex-` arm is defensive: the lexer currently emits `parse-`-prefixed kinds, but a future
+    // dedicated lexer prefix should still map to Error rather than fall through to Warning.
+    private static DiagnosticSeverity SeverityFor(string kind) =>
+        kind.StartsWith("parse-", StringComparison.Ordinal) || kind.StartsWith("lex-", StringComparison.Ordinal)
+            ? DiagnosticSeverity.Error
+            : DiagnosticSeverity.Warning;
+}

--- a/Vidyano.Script.LanguageServer/IDiagnosticSink.cs
+++ b/Vidyano.Script.LanguageServer/IDiagnosticSink.cs
@@ -1,0 +1,18 @@
+using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
+
+namespace Vidyano.Script.LanguageServer;
+
+/// <summary>
+/// Where analysis results go after a document is opened or changed. This is the one seam that lets the
+/// full document→publish round-trip be asserted with no real pipe: production publishes over JSON-RPC,
+/// tests record-and-assert.
+/// </summary>
+/// <remarks>
+/// An empty <paramref name="diagnostics"/> list is meaningful — it clears the previously published set
+/// for that document. The service always publishes (even on a clean document) so editors see stale
+/// problems disappear.
+/// </remarks>
+public interface IDiagnosticSink
+{
+    Task PublishAsync(string uri, IReadOnlyList<LspDiagnostic> diagnostics, CancellationToken ct);
+}

--- a/Vidyano.Script.LanguageServer/Vidyano.Script.LanguageServer.csproj
+++ b/Vidyano.Script.LanguageServer/Vidyano.Script.LanguageServer.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>13</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Vidyano.Script.LanguageServer</RootNamespace>
+    <AssemblyName>Vidyano.Script.LanguageServer</AssemblyName>
+    <Version>5.59.0</Version>
+    <!-- Not shipped as a standalone NuGet package: the language server reaches users bundled inside the
+         `vidyano` dotnet tool, which ProjectReferences this library. This keeps the OmniSharp dependency
+         off a published surface and avoids a third companion package (only Vidyano.Script + .Tool ship). -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Vidyano.Script\Vidyano.Script.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
+  </ItemGroup>
+
+</Project>

--- a/Vidyano.Script.LanguageServer/ViscLanguageService.cs
+++ b/Vidyano.Script.LanguageServer/ViscLanguageService.cs
@@ -1,0 +1,184 @@
+using System.Collections.Concurrent;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Vidyano.Script;
+using Vidyano.Script.Diagnostics;
+using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Vidyano.Script.LanguageServer;
+
+/// <summary>
+/// The pure, transport-free brain of the .visc language server. It owns document state, runs the
+/// existing lex+parse pipeline on every change, and answers hover — naming no JSON-RPC or stdio type on
+/// its hot path. Diagnostics leave through the single <see cref="IDiagnosticSink"/> port, so the whole
+/// open→publish round-trip is observable in a unit test without a real LSP client.
+/// </summary>
+public sealed class ViscLanguageService
+{
+    private readonly IDiagnosticSink _sink;
+    private readonly ConcurrentDictionary<string, string> _documents = new(StringComparer.Ordinal);
+
+    public ViscLanguageService(IDiagnosticSink sink) => _sink = sink;
+
+    /// <summary>Records a freshly opened document and publishes its diagnostics.</summary>
+    public Task DidOpenAsync(string uri, string text, CancellationToken ct = default) =>
+        AnalyzeAndPublishAsync(uri, text, ct);
+
+    /// <summary>Replaces a document's text (full-document sync) and republishes.</summary>
+    public Task DidChangeAsync(string uri, string text, CancellationToken ct = default) =>
+        AnalyzeAndPublishAsync(uri, text, ct);
+
+    /// <summary>Forgets a closed document and clears its diagnostics from the editor.</summary>
+    public Task DidCloseAsync(string uri, CancellationToken ct = default)
+    {
+        _documents.TryRemove(uri, out _);
+        return _sink.PublishAsync(uri, [], ct);
+    }
+
+    /// <summary>Returns verb documentation for the word under <paramref name="position"/>, or
+    /// <c>null</c> when the cursor is not on a known verb (whitespace, an argument, an unknown lexeme).</summary>
+    public Hover? Hover(string uri, Position position)
+    {
+        if (!_documents.TryGetValue(uri, out var text))
+            return null;
+
+        var word = WordAt(text, position, out var range);
+        if (word is null || !VerbCatalog.TryGet(word, out var info))
+            return null;
+
+        return new Hover
+        {
+            Range = range,
+            Contents = new MarkedStringsOrMarkupContent(new MarkupContent
+            {
+                Kind = MarkupKind.Markdown,
+                Value = RenderHover(info),
+            }),
+        };
+    }
+
+    private async Task AnalyzeAndPublishAsync(string uri, string text, CancellationToken ct)
+    {
+        _documents[uri] = text;
+        var diagnostics = VidyanoScript.Lint(text, uri);
+        var mapped = new List<LspDiagnostic>(diagnostics.Count);
+        foreach (var d in diagnostics)
+            mapped.Add(DiagnosticMapper.ToLsp(d, text));
+        await _sink.PublishAsync(uri, mapped, ct).ConfigureAwait(false);
+    }
+
+    private static string RenderHover(VerbInfo info)
+    {
+        var doc = info.MarkdownDoc ?? info.Summary;
+        var examples = info.Examples.Count > 0
+            ? "\n\n```visc\n" + string.Join("\n", info.Examples) + "\n```"
+            : string.Empty;
+        return $"**{info.Name}**\n\n```\n{info.Syntax}\n```\n\n{doc}{examples}";
+    }
+
+    // === Coordinate translation — exposed static so the math is unit-testable without a service. ===
+    // Tokens carry only a start SourceLocation (no length), so an LSP Range can't be read off a token;
+    // it is re-derived from the document text here. This is the deliberate "tokens have no length" leak.
+
+    /// <summary>Maps a 1-based engine location to a 0-based LSP (line, UTF-16 character) point. The engine
+    /// column counts Unicode characters; LSP counts UTF-16 code units, so astral characters before the
+    /// column widen it. <see cref="SourceLocation.Unknown"/> (line 0) collapses to <c>(0, 0)</c>.</summary>
+    public static (int Line, int Char) ToLsp(SourceLocation loc, string text)
+    {
+        if (loc.Line <= 0)
+            return (0, 0);
+
+        var lspLine = loc.Line - 1;
+        var lineText = LineText(text, lspLine);
+
+        // Walk `Column - 1` Unicode characters into the line, summing UTF-16 code units.
+        var targetChars = Math.Max(0, loc.Column - 1);
+        var charUnits = 0;
+        var consumed = 0;
+        while (consumed < targetChars && charUnits < lineText.Length)
+        {
+            charUnits += char.IsHighSurrogate(lineText[charUnits]) && charUnits + 1 < lineText.Length ? 2 : 1;
+            consumed++;
+        }
+        return (lspLine, charUnits);
+    }
+
+    /// <summary>Widens a point location into the <see cref="Range"/> of the word under it (verbs and
+    /// hyphenated verbs are one word). When the point is not on an identifier, returns a zero-width range
+    /// at the point. <see cref="SourceLocation.Unknown"/> collapses to a zero-width range at <c>(0, 0)</c>.</summary>
+    public static Range RangeAt(SourceLocation loc, string text)
+    {
+        // The Unknown sentinel has no place in the document; collapse to a zero-width range at the
+        // origin rather than letting the (0,0) fallback expand into whatever word starts the file.
+        if (loc.Line <= 0)
+            return new Range(new Position(0, 0), new Position(0, 0));
+
+        var (line, ch) = ToLsp(loc, text);
+        var lineText = LineText(text, line);
+
+        if (ch >= lineText.Length || !IsIdentStart(lineText[ch]))
+            return new Range(new Position(line, ch), new Position(line, ch));
+
+        var start = ch;
+        while (start > 0 && IsIdentCont(lineText[start - 1]))
+            start--;
+        var end = ch;
+        while (end < lineText.Length && IsIdentCont(lineText[end]))
+            end++;
+        return new Range(new Position(line, start), new Position(line, end));
+    }
+
+    private static string? WordAt(string text, Position position, out Range range)
+    {
+        var lineText = LineText(text, position.Line);
+        var ch = position.Character;
+        range = new Range(position, position);
+
+        // Hover only when the cursor sits on an identifier character. Whitespace, punctuation, and the
+        // EOL position resolve to no word — so a space between tokens never hovers the preceding verb.
+        if (ch < 0 || ch >= lineText.Length || !IsIdentCont(lineText[ch]))
+            return null;
+
+        var start = ch;
+        while (start > 0 && IsIdentCont(lineText[start - 1]))
+            start--;
+        var end = ch;
+        while (end < lineText.Length && IsIdentCont(lineText[end]))
+            end++;
+
+        if (!IsIdentStart(lineText[start]))
+            return null;
+
+        range = new Range(new Position(position.Line, start), new Position(position.Line, end));
+        return lineText.Substring(start, end - start);
+    }
+
+    private static string LineText(string text, int lspLine)
+    {
+        var lineStart = 0;
+        var currentLine = 0;
+        for (var i = 0; i < text.Length && currentLine < lspLine; i++)
+        {
+            if (text[i] == '\n')
+            {
+                currentLine++;
+                lineStart = i + 1;
+            }
+        }
+        if (currentLine < lspLine)
+            return string.Empty;
+
+        var lineEnd = text.IndexOf('\n', lineStart);
+        if (lineEnd < 0)
+            lineEnd = text.Length;
+        // Trim a trailing CR so a CRLF document's columns match the engine's char counting.
+        if (lineEnd > lineStart && text[lineEnd - 1] == '\r')
+            lineEnd--;
+        return text.Substring(lineStart, lineEnd - lineStart);
+    }
+
+    // Mirrors the Lexer's private IsIdentStart/IsIdentCont (Lexer.cs:348-349) so hyphenated verbs like
+    // SIGN-IN and SELECT-ROWS are treated as a single word for hover and range derivation.
+    private static bool IsIdentStart(char c) => char.IsLetter(c) || c == '_';
+    private static bool IsIdentCont(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '-';
+}

--- a/Vidyano.Script.LanguageServer/ViscLanguageService.cs
+++ b/Vidyano.Script.LanguageServer/ViscLanguageService.cs
@@ -155,6 +155,11 @@ public sealed class ViscLanguageService
 
     private static string LineText(string text, int lspLine)
     {
+        // A malformed client position can carry a negative line; clamp to empty rather than letting the
+        // walk fall through and return line 0.
+        if (lspLine < 0)
+            return string.Empty;
+
         var lineStart = 0;
         var currentLine = 0;
         for (var i = 0; i < text.Length && currentLine < lspLine; i++)

--- a/Vidyano.Script.LanguageServer/ViscLspServer.cs
+++ b/Vidyano.Script.LanguageServer/ViscLspServer.cs
@@ -34,9 +34,16 @@ public static class ViscLspServer
             ?? typeof(ViscLspServer).Assembly.GetName().Version?.ToString()
             ?? "0.0.0").Split('+')[0];
 
+        // stdout is the JSON-RPC channel: bind it to the LSP transport up front, then point Console.Out at
+        // stderr so any stray Console.Write (ours or a dependency's) lands on stderr instead of corrupting
+        // the protocol stream.
+        var stdin = Console.OpenStandardInput();
+        var stdout = Console.OpenStandardOutput();
+        Console.SetOut(Console.Error);
+
         var server = await OmniLanguageServer.From(options => options
-            .WithInput(Console.OpenStandardInput())
-            .WithOutput(Console.OpenStandardOutput())
+            .WithInput(stdin)
+            .WithOutput(stdout)
             .WithServerInfo(new ServerInfo { Name = "vidyano-lsp", Version = version })
             .WithServices(services => services.AddSingleton(service))
             .OnDidOpenTextDocument(async (p, c) =>
@@ -70,22 +77,25 @@ public static class ViscLspServer
         return 0;
     }
 
-    // Publishes through the running server. The server is set once after From(...) returns; before that
-    // (during the handshake) no document handler can fire, so the field is always populated when used.
+    // Publishes through the running server. The server instance is only available after From(...) returns,
+    // but OmniSharp's message loop can dispatch a didOpen the moment the handshake completes — possibly
+    // before this method's Attach continuation runs. Awaiting a TaskCompletionSource closes that race: an
+    // early publish parks until the server is attached instead of being silently dropped.
     private sealed class PublishingSink : IDiagnosticSink
     {
-        private OmniLanguageServer? _server;
+        private readonly TaskCompletionSource<OmniLanguageServer> _serverTcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public void Attach(OmniLanguageServer server) => _server = server;
+        public void Attach(OmniLanguageServer server) => _serverTcs.TrySetResult(server);
 
-        public Task PublishAsync(string uri, IReadOnlyList<LspDiagnostic> diagnostics, CancellationToken ct)
+        public async Task PublishAsync(string uri, IReadOnlyList<LspDiagnostic> diagnostics, CancellationToken ct)
         {
-            _server?.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            var server = await _serverTcs.Task.ConfigureAwait(false);
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
             {
                 Uri = DocumentUri.Parse(uri),
                 Diagnostics = new Container<LspDiagnostic>(diagnostics),
             });
-            return Task.CompletedTask;
         }
     }
 }

--- a/Vidyano.Script.LanguageServer/ViscLspServer.cs
+++ b/Vidyano.Script.LanguageServer/ViscLspServer.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Server;
+using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
+using OmniLanguageServer = OmniSharp.Extensions.LanguageServer.Server.LanguageServer;
+
+namespace Vidyano.Script.LanguageServer;
+
+/// <summary>
+/// The opaque composition root: the only type that touches OmniSharp, JSON-RPC, stdin, and stdout.
+/// It wires a <see cref="ViscLanguageService"/> to the LSP framework's text-document and hover handlers
+/// and publishes diagnostics back over the wire. There is no logic worth a unit test here — everything
+/// testable lives in <see cref="ViscLanguageService"/> and <see cref="DiagnosticMapper"/>.
+/// </summary>
+public static class ViscLspServer
+{
+    private static readonly TextDocumentSelector ViscSelector =
+        TextDocumentSelector.ForLanguage("visc");
+
+    public static async Task<int> RunStdioAsync(CancellationToken ct = default)
+    {
+        var sink = new PublishingSink();
+        var service = new ViscLanguageService(sink);
+
+        // Advertise the tool version over LSP initialize (serverInfo.version) so the editor client can run
+        // its version-skew check. Strip any "+buildmetadata" so the value is a plain major.minor.patch.
+        var version = (typeof(ViscLspServer).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? typeof(ViscLspServer).Assembly.GetName().Version?.ToString()
+            ?? "0.0.0").Split('+')[0];
+
+        var server = await OmniLanguageServer.From(options => options
+            .WithInput(Console.OpenStandardInput())
+            .WithOutput(Console.OpenStandardOutput())
+            .WithServerInfo(new ServerInfo { Name = "vidyano-lsp", Version = version })
+            .WithServices(services => services.AddSingleton(service))
+            .OnDidOpenTextDocument(async (p, c) =>
+                await service.DidOpenAsync(
+                    p.TextDocument.Uri.ToString(), p.TextDocument.Text, c).ConfigureAwait(false),
+                (_, _) => new TextDocumentSyncRegistrationOptions(TextDocumentSyncKind.Full)
+                {
+                    DocumentSelector = ViscSelector,
+                })
+            .OnDidChangeTextDocument(async (p, c) =>
+                await service.DidChangeAsync(
+                    p.TextDocument.Uri.ToString(), p.ContentChanges.LastOrDefault()?.Text ?? "", c).ConfigureAwait(false),
+                (_, _) => new TextDocumentChangeRegistrationOptions
+                {
+                    DocumentSelector = ViscSelector,
+                    SyncKind = TextDocumentSyncKind.Full,
+                })
+            .OnDidCloseTextDocument(async (p, c) =>
+                await service.DidCloseAsync(p.TextDocument.Uri.ToString(), c).ConfigureAwait(false),
+                (_, _) => new TextDocumentCloseRegistrationOptions
+                {
+                    DocumentSelector = ViscSelector,
+                })
+            .OnHover((p, c) => Task.FromResult(
+                    service.Hover(p.TextDocument.Uri.ToString(), p.Position)),
+                (_, _) => new HoverRegistrationOptions { DocumentSelector = ViscSelector }))
+            .ConfigureAwait(false);
+
+        sink.Attach(server);
+        await server.WaitForExit.ConfigureAwait(false);
+        return 0;
+    }
+
+    // Publishes through the running server. The server is set once after From(...) returns; before that
+    // (during the handshake) no document handler can fire, so the field is always populated when used.
+    private sealed class PublishingSink : IDiagnosticSink
+    {
+        private OmniLanguageServer? _server;
+
+        public void Attach(OmniLanguageServer server) => _server = server;
+
+        public Task PublishAsync(string uri, IReadOnlyList<LspDiagnostic> diagnostics, CancellationToken ct)
+        {
+            _server?.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            {
+                Uri = DocumentUri.Parse(uri),
+                Diagnostics = new Container<LspDiagnostic>(diagnostics),
+            });
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Vidyano.Script.Tests/CoordinateMappingTests.cs
+++ b/Vidyano.Script.Tests/CoordinateMappingTests.cs
@@ -1,0 +1,80 @@
+using Vidyano.Script.Diagnostics;
+using Vidyano.Script.LanguageServer;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Unit tests for the coordinate math exposed as statics on <see cref="ViscLanguageService"/> — the
+/// "tokens carry no length" honesty leak. These run with no service instance and no document cache.
+/// </summary>
+public sealed class CoordinateMappingTests
+{
+    [Fact]
+    public void ToLsp_OneBasedCharColumn_BecomesZeroBased()
+    {
+        var loc = new SourceLocation("<t>", 2, 3); // line 2, column 3 (1-based)
+        var (line, ch) = ViscLanguageService.ToLsp(loc, "first line\nSET Name = 1");
+        Assert.Equal(1, line);
+        Assert.Equal(2, ch);
+    }
+
+    [Fact]
+    public void ToLsp_AstralCharacterBeforeColumn_ShiftsToUtf16CodeUnit()
+    {
+        // The emoji is one Unicode char but two UTF-16 code units. The engine column counts it as one;
+        // LSP expects the second column (after it) to be code-unit 2.
+        var text = "\U0001F600X"; // U+1F600 then 'X'
+        var loc = new SourceLocation("<t>", 1, 2); // column 2 = the 'X', 1-based char
+        var (line, ch) = ViscLanguageService.ToLsp(loc, text);
+        Assert.Equal(0, line);
+        Assert.Equal(2, ch); // surrogate pair pushed the X to code unit 2
+    }
+
+    [Fact]
+    public void ToLsp_UnknownLocation_CollapsesToOrigin()
+    {
+        var (line, ch) = ViscLanguageService.ToLsp(SourceLocation.Unknown, "anything");
+        Assert.Equal(0, line);
+        Assert.Equal(0, ch);
+    }
+
+    [Fact]
+    public void RangeAt_PointInsideWord_SpansTheWholeWord()
+    {
+        var text = "OPEN-ROW 0";
+        var loc = new SourceLocation("<t>", 1, 3); // inside "OPEN-ROW"
+        var range = ViscLanguageService.RangeAt(loc, text);
+        Assert.Equal(0, range.Start.Character);
+        Assert.Equal(8, range.End.Character); // "OPEN-ROW" length, hyphen included
+    }
+
+    [Fact]
+    public void RangeAt_PointNotOnIdentifier_IsZeroWidth()
+    {
+        var text = "SET Name = 1";
+        var loc = new SourceLocation("<t>", 1, 4); // the space before "Name"
+        var range = ViscLanguageService.RangeAt(loc, text);
+        Assert.Equal(3, range.Start.Character);
+        Assert.Equal(range.Start.Character, range.End.Character); // zero width
+    }
+
+    [Fact]
+    public void RangeAt_PastEndOfLine_FallsBackToZeroWidthAtPoint()
+    {
+        var text = "SET";
+        var loc = new SourceLocation("<t>", 1, 10); // far past EOL
+        var range = ViscLanguageService.RangeAt(loc, text);
+        Assert.Equal(range.Start.Character, range.End.Character); // EOL fallback, zero width
+    }
+
+    [Fact]
+    public void RangeAt_UnknownLocation_IsZeroWidthAtOrigin()
+    {
+        var range = ViscLanguageService.RangeAt(SourceLocation.Unknown, "SET Name = 1");
+        Assert.Equal(0, range.Start.Line);
+        Assert.Equal(0, range.Start.Character);
+        Assert.Equal(0, range.End.Line);
+        Assert.Equal(0, range.End.Character);
+    }
+}

--- a/Vidyano.Script.Tests/LanguageServerContractTests.cs
+++ b/Vidyano.Script.Tests/LanguageServerContractTests.cs
@@ -1,0 +1,183 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Vidyano.Script.Diagnostics;
+using Vidyano.Script.LanguageServer;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Supplementary contract coverage for the static language server: gaps in the coordinate math, the
+/// diagnostic round-trip's wire shape (Source/Code/Message), CRLF handling, the hover Range, and catalog
+/// integrity. Complements <see cref="CoordinateMappingTests"/>, <see cref="LanguageServiceTests"/>, and
+/// <see cref="VerbCatalogReconciliationTests"/> without restating them.
+/// </summary>
+public sealed class LanguageServerContractTests
+{
+    private const string Uri = "file:///t.visc";
+
+    // === Coordinate math edges (statics, no service instance) ===
+
+    [Fact]
+    public void ToLsp_AstralCharacterOnSecondLine_ShiftsColumnOnThatLineOnly()
+    {
+        // The astral char lives on line 2; ToLsp must walk line 2's text (not line 1) to widen the column.
+        var text = "SET A = 1\n\U0001F600X";
+        var loc = new SourceLocation("<t>", 2, 2); // line 2, column 2 = the 'X' (1-based char)
+        var (line, ch) = ViscLanguageService.ToLsp(loc, text);
+        Assert.Equal(1, line);
+        Assert.Equal(2, ch); // the surrogate pair pushed 'X' to code unit 2 on its own line
+    }
+
+    [Fact]
+    public void ToLsp_ColumnPastEndOfLine_ClampsToLineLengthInCodeUnits()
+    {
+        // A column beyond the line's characters must not walk off the end; it clamps at the line length.
+        var text = "SET"; // 3 chars
+        var loc = new SourceLocation("<t>", 1, 99);
+        var (line, ch) = ViscLanguageService.ToLsp(loc, text);
+        Assert.Equal(0, line);
+        Assert.Equal(3, ch); // clamped to the 3 code units of "SET"
+    }
+
+    [Fact]
+    public void RangeAt_IndentedHyphenatedVerb_SpansTheWholeVerbAtItsColumn()
+    {
+        // Leading spaces shift the verb right; the range must start at the verb, not column 0, and the
+        // hyphen must stay inside the single word.
+        var text = "    SIGN-IN admin / pw";
+        var loc = new SourceLocation("<t>", 1, 8); // inside "SIGN-IN" (1-based char; col 5 = 'S')
+        var range = ViscLanguageService.RangeAt(loc, text);
+        Assert.Equal(4, range.Start.Character);  // "SIGN-IN" starts after 4 spaces
+        Assert.Equal(11, range.End.Character);   // 4 + len("SIGN-IN")=7 => 11
+    }
+
+    [Fact]
+    public void ToLsp_CrlfDocument_CountsColumnsWithoutTheTrailingCarriageReturn()
+    {
+        // The engine counts characters per line; LineText trims a trailing CR so a CRLF doc's columns line
+        // up with the engine's char counting rather than being thrown off by the \r.
+        var text = "SET A = 1\r\nEXPECT B = 2";
+        var loc = new SourceLocation("<t>", 2, 1); // line 2, column 1 = 'E' of EXPECT
+        var (line, ch) = ViscLanguageService.ToLsp(loc, text);
+        Assert.Equal(1, line);
+        Assert.Equal(0, ch);
+    }
+
+    // === Diagnostic round-trip wire shape (through the public service + recording sink) ===
+
+    [Fact]
+    public async Task DidOpen_Diagnostic_CarriesViscSourceAndKindAsCode()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "EXPEKT TotalItems = 3");
+
+        var d = Assert.Single(sink.Last(Uri));
+        Assert.Equal("visc", d.Source);
+        Assert.Equal("parse-unknown-verb", d.Code!.Value.String);
+    }
+
+    [Fact]
+    public async Task DidOpen_Diagnostic_FoldsTheHintIntoTheMessage()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "EXPEKT TotalItems = 3");
+
+        // The engine attaches a "did you mean" hint to an unknown verb; the mapper appends it to Message
+        // so a flat LSP message string carries both halves.
+        var d = Assert.Single(sink.Last(Uri));
+        Assert.StartsWith("Unknown verb 'EXPEKT'.", d.Message);
+        Assert.True(d.Message.Length > "Unknown verb 'EXPEKT'.".Length, "the hint should be folded in");
+    }
+
+    [Fact]
+    public async Task DidOpen_IndentedUnknownVerb_RangeStartsAtTheVerbNotColumnZero()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "   EXPEKT TotalItems = 3"); // 3 leading spaces
+
+        var d = Assert.Single(sink.Last(Uri));
+        Assert.Equal(0, d.Range.Start.Line);
+        Assert.Equal(3, d.Range.Start.Character);
+        Assert.Equal(9, d.Range.End.Character); // 3 + len("EXPEKT")=6 => 9
+    }
+
+    [Fact]
+    public async Task DidChange_ReplacesDocumentText_SoStaleHoverIsGone()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "OPEN MenuItem X");
+        Assert.NotNull(svc.Hover(Uri, new Position(0, 1))); // "OPEN" resolves
+
+        await svc.DidChangeAsync(Uri, "EXPEKT TotalItems = 3"); // full-document replace
+
+        // The old verb no longer exists at that position; the change replaced the cached text.
+        Assert.Null(svc.Hover(Uri, new Position(0, 1)));
+    }
+
+    // === Hover range (the implementer asserts content; pin the Range too) ===
+
+    [Fact]
+    public async Task Hover_OnHyphenatedVerb_RangeSpansTheWholeVerb()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        await svc.DidOpenAsync(Uri, "SIGN-IN admin / admin");
+
+        var hover = svc.Hover(Uri, new Position(0, 6)); // inside "IN", past the hyphen
+
+        Assert.NotNull(hover);
+        Assert.NotNull(hover!.Range);
+        Assert.Equal(0, hover.Range!.Start.Character);
+        Assert.Equal(7, hover.Range.End.Character); // len("SIGN-IN") = 7
+    }
+
+    [Fact]
+    public async Task Hover_AtEndOfLine_ReturnsNull()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        await svc.DidOpenAsync(Uri, "OPEN");
+
+        // Position one past the last character of "OPEN" is the EOL slot — no word there.
+        Assert.Null(svc.Hover(Uri, new Position(0, 4)));
+    }
+
+    // === Catalog integrity beyond "has an example" ===
+
+    [Fact]
+    public void EveryVerb_HasNonEmptySyntaxAndSummary()
+    {
+        Assert.All(VerbCatalog.All, v =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(v.Name), "verb name must be set");
+            Assert.False(string.IsNullOrWhiteSpace(v.Syntax), $"{v.Name} must have a syntax form");
+            Assert.False(string.IsNullOrWhiteSpace(v.Summary), $"{v.Name} must have a summary");
+            Assert.False(string.IsNullOrWhiteSpace(v.Category), $"{v.Name} must have a category");
+        });
+    }
+
+    [Fact]
+    public async Task EveryVerb_RendersAHoverWithoutThrowing()
+    {
+        // Hover formatting reads Syntax/Summary/MarkdownDoc/Examples for each verb; exercise all of them so
+        // a malformed catalog entry surfaces here rather than only when a user hovers that verb.
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        foreach (var v in VerbCatalog.All)
+        {
+            var uri = $"file:///{v.Name}.visc";
+            await svc.DidOpenAsync(uri, v.Name);
+            var hover = svc.Hover(uri, new Position(0, 0));
+            Assert.NotNull(hover);
+            Assert.Contains($"**{v.Name}**", hover!.Contents.MarkupContent!.Value);
+        }
+    }
+}

--- a/Vidyano.Script.Tests/LanguageServiceTests.cs
+++ b/Vidyano.Script.Tests/LanguageServiceTests.cs
@@ -1,0 +1,125 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Vidyano.Script.LanguageServer;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Drives <see cref="ViscLanguageService"/> through its public surface and the one
+/// <see cref="IDiagnosticSink"/> port — no stdio, no JSON-RPC, no real LSP client. Asserts the
+/// document→publish round-trip and hover, exactly as an editor would observe them.
+/// </summary>
+public sealed class LanguageServiceTests
+{
+    private const string Uri = "file:///t.visc";
+
+    [Fact]
+    public async Task DidOpen_UnknownVerb_PublishesError()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "SIGN-IN steve / pw\nEXPEKT TotalItems = 3");
+
+        var published = Assert.Single(sink.Last(Uri));
+        Assert.Equal("parse-unknown-verb", published.Code!.Value.String);
+        Assert.Equal(DiagnosticSeverity.Error, published.Severity);
+        Assert.Equal(1, published.Range.Start.Line); // 0-based -> source line 2
+        Assert.Equal(0, published.Range.Start.Character);
+        Assert.Equal(6, published.Range.End.Character); // "EXPEKT" is 6 chars wide
+    }
+
+    [Fact]
+    public async Task DidOpen_UnterminatedString_PublishesLexErrorAsError()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        // The lexer flags an unterminated string when a newline interrupts the literal.
+        await svc.DidOpenAsync(Uri, "SET Name = \"unterminated\nEXPECT TotalItems = 1");
+
+        Assert.Contains(sink.Last(Uri), d =>
+            d.Code!.Value.String == "parse-unterminated-string" && d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public async Task DidChange_CleanDocument_PublishesEmptyToClearStaleDiagnostics()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "EXPEKT TotalItems = 3"); // one error
+        Assert.NotEmpty(sink.Last(Uri));
+
+        await svc.DidChangeAsync(Uri, "EXPECT TotalItems = 3"); // now clean
+
+        Assert.Empty(sink.Last(Uri)); // empty publish clears the prior set
+    }
+
+    [Fact]
+    public async Task DidClose_ClearsDiagnostics()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+
+        await svc.DidOpenAsync(Uri, "EXPEKT TotalItems = 3");
+        await svc.DidCloseAsync(Uri);
+
+        Assert.Empty(sink.Last(Uri));
+    }
+
+    [Fact]
+    public async Task Hover_InsideVerb_ReturnsVerbMarkdown()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        await svc.DidOpenAsync(Uri, "OPEN MenuItem Sales/Customers");
+
+        var hover = svc.Hover(Uri, new Position(0, 2)); // inside "OPEN"
+
+        Assert.NotNull(hover);
+        Assert.True(hover!.Contents.HasMarkupContent);
+        Assert.Contains("navigation stack", hover.Contents.MarkupContent!.Value);
+    }
+
+    [Fact]
+    public async Task Hover_OnHyphenatedVerb_TreatsWholeVerbAsOneWord()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        await svc.DidOpenAsync(Uri, "SIGN-IN admin / admin");
+
+        // Position past the hyphen, inside "IN" — the whole "SIGN-IN" must resolve, not "SIGN".
+        var hover = svc.Hover(Uri, new Position(0, 6));
+
+        Assert.NotNull(hover);
+        Assert.Contains("**SIGN-IN**", hover!.Contents.MarkupContent!.Value);
+    }
+
+    [Fact]
+    public async Task Hover_OnWhitespace_ReturnsNull()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        await svc.DidOpenAsync(Uri, "OPEN MenuItem X");
+
+        Assert.Null(svc.Hover(Uri, new Position(0, 4))); // the space after OPEN
+    }
+
+    [Fact]
+    public async Task Hover_OnUnknownLexeme_ReturnsNull()
+    {
+        var sink = new RecordingDiagnosticSink();
+        var svc = new ViscLanguageService(sink);
+        await svc.DidOpenAsync(Uri, "EXPEKT TotalItems = 3");
+
+        Assert.Null(svc.Hover(Uri, new Position(0, 2))); // inside the misspelled verb
+    }
+
+    [Fact]
+    public void Hover_UnknownDocument_ReturnsNull()
+    {
+        var svc = new ViscLanguageService(new RecordingDiagnosticSink());
+        Assert.Null(svc.Hover("file:///never-opened.visc", new Position(0, 0)));
+    }
+}

--- a/Vidyano.Script.Tests/RecordingDiagnosticSink.cs
+++ b/Vidyano.Script.Tests/RecordingDiagnosticSink.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+using Vidyano.Script.LanguageServer;
+using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// In-process <see cref="IDiagnosticSink"/> that records every publish so the document→publish
+/// round-trip can be asserted with no real LSP pipe. Keeps the latest publish per uri.
+/// </summary>
+internal sealed class RecordingDiagnosticSink : IDiagnosticSink
+{
+    private readonly ConcurrentDictionary<string, IReadOnlyList<LspDiagnostic>> _last = new();
+
+    public int PublishCount { get; private set; }
+
+    public Task PublishAsync(string uri, IReadOnlyList<LspDiagnostic> diagnostics, CancellationToken ct)
+    {
+        _last[uri] = diagnostics;
+        PublishCount++;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>The most recently published diagnostic set for <paramref name="uri"/>.</summary>
+    public IReadOnlyList<LspDiagnostic> Last(string uri) => _last[uri];
+}

--- a/Vidyano.Script.Tests/VerbCatalogReconciliationTests.cs
+++ b/Vidyano.Script.Tests/VerbCatalogReconciliationTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using Vidyano.Script;
+using Vidyano.Script.Diagnostics;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// The keystone guard: proves the three historical verb-knowledge sources actually collapsed into
+/// <see cref="VerbCatalog"/>. If a verb is added to the parser but not the catalog (or vice versa),
+/// one of these assertions fails.
+/// </summary>
+public sealed class VerbCatalogReconciliationTests
+{
+    // The authoritative set the parser recognized before the catalog existed (Parser.cs:20-28).
+    // VerbCatalog.Names is internal to Vidyano.Script, so this list stands in as the contract under test.
+    private static readonly string[] HistoricalKnownVerbs =
+    [
+        "SIGN-IN", "SIGN-OUT", "USE", "OPEN", "OPEN-ROW", "GO-BACK", "FOLLOW", "OPEN-DETAIL",
+        "EDIT", "CANCEL", "SAVE", "REFRESH", "RELOAD",
+        "SET", "ACTION", "SEARCH", "SELECT-ROWS",
+        "EXPECT", "GOTO",
+        "TOOL",
+        "REQUIRES", "CLEANUP",
+    ];
+
+    [Fact]
+    public void EveryHistoricalKnownVerb_ResolvesInCatalog()
+    {
+        foreach (var verb in HistoricalKnownVerbs)
+            Assert.True(VerbCatalog.TryGet(verb, out _), $"VerbCatalog is missing '{verb}'.");
+    }
+
+    [Fact]
+    public void EveryCatalogVerb_IsRecognizedByTheParser()
+    {
+        // A verb in the catalog must pass the parser's known-verb gate. Some recognized verbs are
+        // "not yet implemented" — they still produce a parse-unknown-verb diagnostic but with a
+        // distinct message — so the reconciliation signal is the *truly-unknown* message, which only
+        // fires for verbs the gate rejected.
+        foreach (var v in VerbCatalog.All)
+        {
+            var diags = VidyanoScript.Lint(v.Name);
+            Assert.DoesNotContain(diags, d => d.Message.StartsWith($"Unknown verb '{v.Name}'", StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
+    public void EveryCatalogEntry_ResolvesToItselfViaTryGet()
+    {
+        // Spec #36: `vidyano help verbs` renders one row per VerbCatalog.All entry, so every rendered
+        // row must resolve through the same TryGet that hover and the parser's known-verb gate use —
+        // otherwise help could list a verb the lookup path can't find. Guards All-vs-TryGet divergence.
+        foreach (var v in VerbCatalog.All)
+        {
+            Assert.True(VerbCatalog.TryGet(v.Name, out var found), $"VerbCatalog.All lists '{v.Name}' but TryGet can't resolve it.");
+            Assert.Same(v, found);
+        }
+    }
+
+    [Fact]
+    public void TrulyUnknownVerb_StillRejected()
+    {
+        var diags = VidyanoScript.Lint("EXPEKT TotalItems = 3");
+        Assert.Contains(diags, d => d.Message.StartsWith("Unknown verb 'EXPEKT'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TryGet_IsCaseInsensitive()
+    {
+        Assert.True(VerbCatalog.TryGet("sign-in", out var info));
+        Assert.Equal("SIGN-IN", info.Name);
+    }
+
+    [Fact]
+    public void TryGet_UnknownLexeme_ReturnsFalse()
+    {
+        Assert.False(VerbCatalog.TryGet("EXPEKT", out _));
+    }
+
+    [Fact]
+    public void CatalogHasNoDuplicateNames()
+    {
+        var names = VerbCatalog.All.Select(v => v.Name).ToList();
+        Assert.Equal(names.Count, names.Distinct().Count());
+    }
+
+    [Fact]
+    public void EveryVerb_HasAtLeastOneExample()
+    {
+        Assert.All(VerbCatalog.All, v => Assert.NotEmpty(v.Examples));
+    }
+}

--- a/Vidyano.Script.Tests/Vidyano.Script.Tests.csproj
+++ b/Vidyano.Script.Tests/Vidyano.Script.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Vidyano.Script\Vidyano.Script.csproj" />
+    <ProjectReference Include="..\Vidyano.Script.LanguageServer\Vidyano.Script.LanguageServer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Vidyano.Script.Tool/Cli.cs
+++ b/Vidyano.Script.Tool/Cli.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Spectre.Console;
 using Vidyano.Script;
+using Vidyano.Script.LanguageServer;
 using Vidyano.Script.Runtime;
 
 namespace Vidyano.Script.Tool;
@@ -48,6 +49,11 @@ public static class Cli
             "run"   => await RunCommand.ExecuteAsync(rest).ConfigureAwait(false),
             "lint"  => await LintCommand.ExecuteAsync(rest).ConfigureAwait(false),
             "repl"  => await ReplCommand.ExecuteAsync(rest).ConfigureAwait(false),
+            // `lsp` speaks LSP over stdio for an editor to drive. It intentionally IGNORES extra args:
+            // LSP launchers (vscode-languageclient) append transport/handshake flags after the subcommand
+            // (e.g. `--stdio`, `--clientProcessId=<pid>`). We must also never write to stdout here — stdout
+            // is the LSP message channel, and any stray bytes corrupt the protocol stream.
+            "lsp"   => await ViscLspServer.RunStdioAsync().ConfigureAwait(false),
             "help"  => Help(rest),
             _ => UnknownCommand(sub),
         };
@@ -56,7 +62,7 @@ public static class Cli
     private static int UnknownCommand(string sub)
     {
         AnsiConsole.MarkupLine($"[red]Unknown command:[/] [yellow]{Markup.Escape(sub)}[/]");
-        var hint = Diagnostics.Suggester.Hint(sub, new[] { "run", "lint", "repl", "help" });
+        var hint = Diagnostics.Suggester.Hint(sub, new[] { "run", "lint", "repl", "lsp", "help" });
         if (hint != null) AnsiConsole.MarkupLine($"[grey]{Markup.Escape(hint)}[/]");
         AnsiConsole.WriteLine();
         PrintUsage();
@@ -84,6 +90,7 @@ public static class Cli
         AnsiConsole.MarkupLine("  vidyano [yellow]run[/]   <file.visc> [grey][[options]][/]   Execute a script.");
         AnsiConsole.MarkupLine("  vidyano [yellow]lint[/]  <file.visc>                  Parse-check without executing.");
         AnsiConsole.MarkupLine("  vidyano [yellow]repl[/]  [grey][[options]][/]                     Start an interactive .visc REPL.");
+        AnsiConsole.MarkupLine("  vidyano [yellow]lsp[/]                            Run the .visc language server over stdio (for editors).");
         AnsiConsole.MarkupLine("  vidyano [yellow]help[/]  [grey][[verbs]][/]                      Show help. 'verbs' lists every .visc verb.");
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[bold]Options shared by run/repl:[/]");

--- a/Vidyano.Script.Tool/VerbReference.cs
+++ b/Vidyano.Script.Tool/VerbReference.cs
@@ -1,11 +1,12 @@
 using Spectre.Console;
+using Vidyano.Script.Diagnostics;
 
 namespace Vidyano.Script.Tool;
 
 /// <summary>
-/// One place that lists every .visc verb with a one-line example. Printed by
-/// <c>vidyano help verbs</c>. Keep this in sync with the parser — drift between this list and the
-/// parser is the most common source of "but I tried that exact syntax" confusion.
+/// Renders the canonical <see cref="VerbCatalog"/> as a Spectre table for <c>vidyano help verbs</c>.
+/// The table holds no verb knowledge of its own — it is a pure view over the catalog, so it can never
+/// drift from the parser's known-verb set again.
 /// </summary>
 public static class VerbReference
 {
@@ -14,52 +15,13 @@ public static class VerbReference
         var t = new Table().Border(TableBorder.Rounded).Title("[bold].visc verb reference[/]");
         t.AddColumn("Verb");
         t.AddColumn("Example");
-        t.AddColumn("Notes");
+        t.AddColumn("Summary");
 
-        t.AddRow("@var = value",         "@app = http://localhost:5000",        "Define a script variable. Reference with {{var}}.");
-        t.AddRow("@mode = ...",          "@mode = audit",                       "navigation (default) | audit | direct. Set before any verb.");
-        t.AddRow("@session.<attr>",      "SET @session.CurrentYear = 2026",     "Read/write Client.Session. Also: EXPECT @session.X = … and {{@session.X}}.");
-        t.AddRow("@initial.<prop>",      "EXPECT @initial.FullTypeName = \"…\"",  "Read Client.Initial (PO scalar or attribute). SAVE @initial clears the gate.");
-        t.AddRow("SIGN-IN",              "SIGN-IN admin / admin",               "Or: SIGN-IN @admin = user / pwd  (named session).");
-        t.AddRow("SIGN-IN FROM ENV",     "SIGN-IN FROM ENV",                    "Reads VIDYANO_USER / VIDYANO_PASSWORD from the environment; loud-fails if either is unset. Optional LANGUAGE xx-XX.");
-        t.AddRow("USE",                  "USE @admin",                          "Switch to a named session (multi-session not yet implemented).");
-        t.AddRow("OPEN PersistentObject","OPEN PersistentObject \"Customer\" \"42\" AS @c","Opens a PO directly. In navigation mode requires reachability.");
-        t.AddRow("OPEN Query",           "OPEN Query Customers AS @customers",  "Opens a query by id.");
-        t.AddRow("OPEN MenuItem",        "OPEN MenuItem Sales/Customers",       "Walks the user's menu (Application.Queries[[ProgramUnits]]).");
-        t.AddRow("OPEN-ROW",             "OPEN-ROW 0 AS @row",                  "Opens the PO behind a row of the current query, by index.");
-        t.AddRow("OPEN-ROW WHERE",       "OPEN-ROW WHERE Name = \"Acme\"",       "Opens the PO behind the single row whose column equals the value. Strict: 0 or >1 matches fail. Value is service-string form, like SET.");
-        t.AddRow("OPEN-ROW Detail",      "OPEN-ROW Detail \"OrderLines\" 0",     "Selects the row from a detail query (PO.Queries[[name]]) instead of the current query. Works with the index or WHERE form.");
-        t.AddRow("SELECT-ROWS",          "SELECT-ROWS ALL",                     "Sets selection for a selection-gated ACTION (e.g. Delete). ALL (server-side select-all) | ALL EXCEPT <index|WHERE> (inverse) | NONE | <index> | WHERE <col> = <val> (non-strict) | Detail \"X\" <target>. Replaces, never accumulates.");
-        t.AddRow("GO-BACK",              "GO-BACK",                             "Pops the top nav frame (browser back). Refuses on a PO in edit, or at the root frame.");
-        t.AddRow("SEARCH",               "SEARCH \"Acme\"",                      "Searches the current query.");
-        t.AddRow("EDIT",                 "EDIT",                                "Enters edit mode on the current PO. SET auto-enters.");
-        t.AddRow("SET",                  "SET Name = \"Acme Corp\"",             "Literal write. Reference attrs auto-resolve via Options/Lookup when no hint is given.");
-        t.AddRow("SET … = LOOKUP",       "SET Status = LOOKUP \"Active\"",       "Match against attr.Options[[]].DisplayValue — works for reference attrs (Lookup query) and non-reference Options-bearing attrs (KeyValueList / Dropdown / ComboBox).");
-        t.AddRow("SET … = ID",           "SET Status = ID \"active\"",           "Raw key match — Options[[]].Key for non-reference attrs, SelectedReferenceValue for reference attrs.");
-        t.AddRow("SET … = null",         "SET Notes = null",                    "Clears the attribute. For reference attrs, requires CanRemoveReference.");
-        t.AddRow("ACTION",               "ACTION Export (Format=\"csv\")",       "Executes an action. Subject to action-availability guard.");
-        t.AddRow("ACTION X = option",    "ACTION Delete = \"Yes, delete\"",      "Choose an Options[[]] entry by label, or by `= ID <index>`. Mutually exclusive with (Param=…).");
-        t.AddRow("ACTION Detail",        "ACTION Detail \"OrderLines\" Delete",  "Targets a detail query (PO.Queries[[name]]) instead of the nav-stack query — resolves+executes the action there, so a SELECT-ROWS Detail selection has a verb to act on.");
-        t.AddRow("SAVE",                 "SAVE",                                "Saves pending edits. Required attributes checked first.");
-        t.AddRow("CANCEL",               "CANCEL",                              "Discards pending edits.");
-        t.AddRow("EXPECT … = …",         "EXPECT Status = \"Approved\"",         "Equality (=,!=) and ordering (<,<=,>,>=) work on attribute values.");
-        t.AddRow("EXPECT … IS NULL",     "EXPECT Notification IS NULL",         "Or IS NOT NULL.");
-        t.AddRow("EXPECT Action … IS …", "EXPECT Action Approve IS AVAILABLE",  "IS [[NOT]] AVAILABLE | VISIBLE.");
-        t.AddRow("EXPECT Attribute … IS","EXPECT Attribute Name IS REQUIRED",   "IS [[NOT]] VISIBLE | READONLY | REQUIRED | AVAILABLE (= IsVisible && !IsReadOnly).");
-        t.AddRow("EXPECT IsDirty",       "EXPECT IsDirty = false",              "Same for IsInEdit.");
-        t.AddRow("EXPECT TotalItems",    "EXPECT TotalItems >= 1",              "On the current query.");
-        t.AddRow("EXPECT Selection.Count","EXPECT Selection.Count = 3",         "Number of selected rows on the current query (Detail-redirectable, like TotalItems).");
-        t.AddRow("EXPECT Selection.AllSelected","EXPECT Selection.AllSelected = true","Server-side select-all flag (Query.AllSelected). True after SELECT-ROWS ALL; Count still reports only literal/exclusion rows.");
-        t.AddRow("EXPECT Attr TYPE",     "EXPECT Attribute X TYPE = \"String\"",  "Or TAG / TYPEHINT key for round-tripped metadata.");
-        t.AddRow("EXPECT PO.<prop>",     "EXPECT PO.Type = \"Customer\"",         "Plus PO.Tag / PO.Metadata.<k> / PO.NavigationHints.<k>.");
-        t.AddRow("EXPECT Query.<prop>",  "EXPECT Query.Columns[[Name]].Label = …", "Plus Query.Metadata.<k>, Query.PersistentObject.Type, etc.");
-        t.AddRow("EXPECT Detail …",      "EXPECT Detail \"OrderLines\" TotalItems = 3", "Targets a detail query on the current PO. Only query subjects (TotalItems / Query.*).");
-        t.AddRow("EXPECT Detail … IS",   "EXPECT Detail \"OrderLines\" IS AVAILABLE", "IS [[NOT]] AVAILABLE | VISIBLE — checks PO.Queries presence / visibility.");
-        t.AddRow("TOOL",                 "TOOL fetch-user id=42 -> @user",      "Registered handler. CLI: load via --tools <pack.dll> (IVidyanoScriptToolPack).");
-        t.AddRow("EXPECT … MATCHES",     "EXPECT Code MATCHES \"^[[A-Z]]{2}\\\\d+$\"", "Regex assertion (1s ReDoS-guard timeout). Null never matches.");
-        t.AddRow("REQUIRES",             "REQUIRES TotalItems >= 1",            "Precondition gate (reuses EXPECT grammar). Unmet → skip rest of body.");
-        t.AddRow("REQUIRES TOOL",        "REQUIRES TOOL seed-db",               "Capability gate: skip the body unless the named tool is registered.");
-        t.AddRow("CLEANUP",              "CLEANUP",                             "Marker; statements after it always run, even when the body was skipped.");
+        foreach (var v in VerbCatalog.All)
+        {
+            var example = v.Examples.Count > 0 ? v.Examples[0] : v.Syntax;
+            t.AddRow(Markup.Escape(v.Name), Markup.Escape(example), Markup.Escape(v.Summary));
+        }
 
         AnsiConsole.Write(t);
         AnsiConsole.WriteLine();

--- a/Vidyano.Script.Tool/Vidyano.Script.Tool.csproj
+++ b/Vidyano.Script.Tool/Vidyano.Script.Tool.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Vidyano.Script\Vidyano.Script.csproj" />
+    <ProjectReference Include="..\Vidyano.Script.LanguageServer\Vidyano.Script.LanguageServer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Vidyano.Script/Diagnostics/VerbCatalog.cs
+++ b/Vidyano.Script/Diagnostics/VerbCatalog.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Vidyano.Script.Diagnostics;
+
+/// <summary>
+/// One verb's documentation: its canonical name, syntax form(s), a one-line summary, optional
+/// long-form markdown (for editor hover), illustrative examples, a grouping category, and any aliases.
+/// </summary>
+public sealed record VerbInfo(
+    string Name,
+    string Syntax,
+    string Summary,
+    string? MarkdownDoc,
+    IReadOnlyList<string> Examples,
+    string Category,
+    IReadOnlyList<string> Aliases);
+
+/// <summary>
+/// The single source of truth for every .visc verb. The parser's known-verb set, the Suggester's
+/// candidate list, <c>vidyano help verbs</c>, and editor hover all read from here — so verb knowledge
+/// can never drift between those surfaces again.
+/// </summary>
+/// <remarks>
+/// Historically there were two diverging lists: <c>Parser.KnownVerbs</c> (which carried
+/// <c>FOLLOW</c>/<c>OPEN-DETAIL</c>/<c>RELOAD</c>/<c>GOTO</c>/<c>REFRESH</c>) and the Tool's
+/// syntax-form-keyed help table (which did not). This catalog reconciles them: it is keyed by bare
+/// verb name and MUST contain every verb the parser recognizes. The catalog-reconciliation guard test
+/// asserts that <c>Parser.KnownVerbs ⊆ VerbCatalog.Names</c>.
+/// </remarks>
+public static class VerbCatalog
+{
+    private static readonly IReadOnlyList<VerbInfo> _all =
+    [
+        new("SIGN-IN",
+            "SIGN-IN <user> / <pwd> [LANGUAGE xx-XX]\nSIGN-IN @name = <user> / <pwd>\nSIGN-IN FROM ENV [LANGUAGE xx-XX]",
+            "Authenticate against the service.",
+            "Authenticate against the Vidyano service. `SIGN-IN FROM ENV` reads `VIDYANO_USER` / "
+            + "`VIDYANO_PASSWORD` from the environment and loud-fails if either is unset. The `@name =` "
+            + "form opens a named session.",
+            ["SIGN-IN admin / admin", "SIGN-IN @admin = user / pwd", "SIGN-IN FROM ENV"],
+            "session", []),
+
+        new("SIGN-OUT",
+            "SIGN-OUT",
+            "End the current session.",
+            null,
+            ["SIGN-OUT"],
+            "session", []),
+
+        new("USE",
+            "USE @name",
+            "Switch to a named session (multi-session not yet implemented).",
+            null,
+            ["USE @admin"],
+            "session", []),
+
+        new("OPEN",
+            "OPEN PersistentObject <type> <id> [AS @h]\nOPEN Query <id> [AS @h]\nOPEN MenuItem <path> [AS @h]",
+            "Push a frame on the navigation stack.",
+            "Pushes a Query, PersistentObject, or MenuItem frame on the navigation stack. In navigation "
+            + "mode `OPEN PersistentObject`/`OPEN Query` require reachability; `OPEN MenuItem` walks the "
+            + "user's menu.",
+            ["OPEN MenuItem Sales/Customers", "OPEN Query Customers AS @customers", "OPEN PersistentObject \"Customer\" \"42\" AS @c"],
+            "navigation", []),
+
+        new("OPEN-ROW",
+            "OPEN-ROW <index> [AS @h]\nOPEN-ROW WHERE <col> = <value> [AS @h]\nOPEN-ROW Detail \"<name>\" <index|WHERE …>",
+            "Push a PO frame from a row of the current query.",
+            "Opens the PersistentObject behind a row of the current query — by index, by `WHERE <col> = "
+            + "<value>` (strict: 0 or >1 matches fail), or from a named detail query via `Detail \"<name>\"`.",
+            ["OPEN-ROW 0 AS @row", "OPEN-ROW WHERE Name = \"Acme\"", "OPEN-ROW Detail \"OrderLines\" 0"],
+            "navigation", []),
+
+        new("GO-BACK",
+            "GO-BACK",
+            "Pop the top navigation frame (browser back).",
+            "Pops the top navigation frame, revealing the one beneath. Refuses when the top is a PO in "
+            + "edit (SAVE or CANCEL first) and when already at the root frame.",
+            ["GO-BACK"],
+            "navigation", []),
+
+        new("FOLLOW",
+            "FOLLOW <attr> [AS @h]",
+            "Follow a reference attribute to its target PO.",
+            null,
+            ["FOLLOW Customer AS @c"],
+            "navigation", []),
+
+        new("OPEN-DETAIL",
+            "OPEN-DETAIL \"<name>\" [AS @h]",
+            "Open a detail query on the current PO as a frame.",
+            null,
+            ["OPEN-DETAIL \"OrderLines\""],
+            "navigation", []),
+
+        new("EDIT",
+            "EDIT",
+            "Enter edit mode on the current PO.",
+            "Enters edit mode on the current PersistentObject. A `SET` auto-enters edit, so an explicit "
+            + "`EDIT` is only needed when you want to assert edit state before changing anything.",
+            ["EDIT"],
+            "edit", []),
+
+        new("CANCEL",
+            "CANCEL",
+            "Discard pending edits.",
+            null,
+            ["CANCEL"],
+            "edit", []),
+
+        new("SAVE",
+            "SAVE [@initial]\nSAVE EXPECTING ERROR",
+            "Persist pending edits.",
+            "Saves pending edits. `SAVE EXPECTING ERROR` asserts the negative path: it passes only if the "
+            + "server returns an error notification, and fails if the save unexpectedly succeeds.",
+            ["SAVE", "SAVE EXPECTING ERROR"],
+            "edit", []),
+
+        new("REFRESH",
+            "REFRESH",
+            "Re-fetch the current PO/query from the server.",
+            null,
+            ["REFRESH"],
+            "edit", []),
+
+        new("RELOAD",
+            "RELOAD",
+            "Reload the current frame from the server.",
+            null,
+            ["RELOAD"],
+            "edit", []),
+
+        new("SET",
+            "SET <attr> = <value>\nSET <attr> = LOOKUP \"<display>\"\nSET <attr> = ID \"<key>\"\nSET <attr> = null",
+            "Change an attribute value.",
+            "Writes an attribute. A bare value is a literal write (reference attrs auto-resolve via "
+            + "Options/Lookup). `LOOKUP` matches `Options[].DisplayValue`; `ID` matches the raw key; "
+            + "`null` clears the attribute.",
+            ["SET Name = \"Acme Corp\"", "SET Status = LOOKUP \"Active\"", "SET Notes = null"],
+            "edit", []),
+
+        new("ACTION",
+            "ACTION <action> [(Param=…)]\nACTION <action> = <option>\nACTION Detail \"<name>\" <action>\nACTION <action> EXPECTING ERROR",
+            "Invoke an action by name.",
+            "Executes an action, subject to the action-availability guard. `= <option>` chooses an "
+            + "`Options[]` entry; `Detail \"<name>\"` targets a detail query; `EXPECTING ERROR` asserts "
+            + "the negative path.",
+            ["ACTION Export (Format=\"csv\")", "ACTION Delete = \"Yes, delete\"", "ACTION Detail \"OrderLines\" Delete"],
+            "action", []),
+
+        new("SEARCH",
+            "SEARCH <text>\nSEARCH Detail \"<name>\" [text]",
+            "Text-search the current query in place.",
+            "Searches the current query without changing the nav stack. A leading `Detail \"<name>\"` "
+            + "retargets a named detail query to load its rows; omit the text to load with an empty filter.",
+            ["SEARCH \"Acme\"", "SEARCH Detail \"OrderLines\""],
+            "query", []),
+
+        new("SELECT-ROWS",
+            "SELECT-ROWS <ALL | ALL EXCEPT <i|WHERE …> | NONE | <i> | WHERE <col> = <value>>\nSELECT-ROWS Detail \"<name>\" <target>",
+            "Set the current query's selection.",
+            "Sets the selection so a selection-gated action (e.g. Delete) can run. `ALL` is server-side "
+            + "select-all (`Query.AllSelected`); `ALL EXCEPT` is inverse selection; `<i>`/`WHERE`/`NONE` "
+            + "set explicit rows. Replaces the selection, never accumulates.",
+            ["SELECT-ROWS ALL", "SELECT-ROWS WHERE Name = \"Acme\"", "SELECT-ROWS NONE"],
+            "query", []),
+
+        new("EXPECT",
+            "EXPECT <subject> <op> <value>\nEXPECT <subject> IS [NOT] <flag>\nEXPECT <lhs> MATCHES \"<regex>\"\nEXPECT Detail \"<name>\" <query-subject>",
+            "Assert on session/PO/query state.",
+            "Asserts on `NavStack.*`, `TotalItems`, `Selection.*`, `IsInEdit`, `ClientOperation`, "
+            + "attributes, notifications, and round-tripped metadata. `MATCHES` is a regex assertion "
+            + "(1s ReDoS guard). `Detail \"<name>\"` redirects query-family subjects.",
+            ["EXPECT Status = \"Approved\"", "EXPECT TotalItems >= 1", "EXPECT Code MATCHES \"^[A-Z]{2}\\d+$\""],
+            "assert", []),
+
+        new("GOTO",
+            "GOTO <step>",
+            "Jump to a labeled step.",
+            null,
+            ["GOTO cleanup"],
+            "control", []),
+
+        new("TOOL",
+            "TOOL <name> [k=v, …] [-> @var]",
+            "Call a registered C# delegate.",
+            "Invokes a registered host delegate with named arguments. Throws become `tool-error` "
+            + "diagnostics. In-process: register on `VidyanoScriptOptions.Tools`. From the CLI: load via "
+            + "`--tools <pack.dll>` (implementing `IVidyanoScriptToolPack`).",
+            ["TOOL fetch-user id=42 -> @user"],
+            "tool", []),
+
+        new("REQUIRES",
+            "REQUIRES <expect-subject> <op> <value>\nREQUIRES TOOL <name>",
+            "Precondition gate; skips the body when unmet.",
+            "A precondition gate reusing the full EXPECT grammar. Holds → pass and continue. Unmet or "
+            + "unevaluable → skip the rest of the body (`state-requires-unmet`, not a failure). "
+            + "`REQUIRES TOOL <name>` is a capability gate.",
+            ["REQUIRES TotalItems >= 1", "REQUIRES TOOL seed-db"],
+            "control", []),
+
+        new("CLEANUP",
+            "CLEANUP",
+            "Marker; statements after it always run.",
+            "A marker statement. Anything after it runs even when the body was skipped by an unmet "
+            + "`REQUIRES` — the .visc equivalent of a finally block.",
+            ["CLEANUP"],
+            "control", []),
+    ];
+
+    private static readonly IReadOnlySet<string> _names =
+        _all.SelectMany(v => v.Aliases.Prepend(v.Name))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly IReadOnlyDictionary<string, VerbInfo> _byName =
+        _all.SelectMany(v => v.Aliases.Prepend(v.Name).Select(n => (Key: n, Verb: v)))
+            .ToDictionary(x => x.Key, x => x.Verb, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Every verb, in declaration order. Read by <c>help verbs</c> and editor hover.</summary>
+    public static IReadOnlyList<VerbInfo> All => _all;
+
+    /// <summary>Looks up a verb by name or alias, case-insensitively.</summary>
+    public static bool TryGet(string lexeme, out VerbInfo info)
+    {
+        if (lexeme is not null && _byName.TryGetValue(lexeme, out var found))
+        {
+            info = found;
+            return true;
+        }
+        info = null!;
+        return false;
+    }
+
+    /// <summary>The case-insensitive set of recognized verb names (names ∪ aliases).
+    /// <see cref="Parsing.Parser"/>'s known-verb gate delegates here.</summary>
+    internal static IReadOnlySet<string> Names => _names;
+}

--- a/Vidyano.Script/Parsing/Parser.cs
+++ b/Vidyano.Script/Parsing/Parser.cs
@@ -17,15 +17,9 @@ public sealed class Parser
     private readonly List<Diagnostic> _diagnostics;
     private int _pos;
 
-    private static readonly HashSet<string> KnownVerbs = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "SIGN-IN", "SIGN-OUT", "USE", "OPEN", "OPEN-ROW", "GO-BACK", "FOLLOW", "OPEN-DETAIL",
-        "EDIT", "CANCEL", "SAVE", "REFRESH", "RELOAD",
-        "SET", "ACTION", "SEARCH", "SELECT-ROWS",
-        "EXPECT", "GOTO",
-        "TOOL",
-        "REQUIRES", "CLEANUP",
-    };
+    // The recognized-verb set delegates to VerbCatalog so verb knowledge lives in exactly one place
+    // (the catalog also feeds `help verbs` and editor hover). See VerbCatalog for the reconciliation note.
+    private static readonly IReadOnlySet<string> KnownVerbs = VerbCatalog.Names;
 
     private static readonly HashSet<string> KnownOpenKinds = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.gitignore
+.vscodeignore
+src/**
+tsconfig.json
+**/*.map
+**/*.ts
+*.vsix

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 2sky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,55 @@
+# Vidyano Script (.visc) — VS Code extension
+
+Syntax highlighting and language-server support (live diagnostics, verb hover) for `.visc`
+Vidyano.Script files.
+
+The extension is a thin client. The actual language server is the `vidyano` .NET tool, launched as
+`vidyano lsp` over stdio (vanilla LSP).
+
+## Prerequisites
+
+Install the Vidyano.Script tool (provides the `vidyano` command on your `PATH`):
+
+```bash
+dotnet tool install -g Vidyano.Script.Tool
+```
+
+Requires the .NET 10 runtime. Update with `dotnet tool update -g Vidyano.Script.Tool`.
+
+If `vidyano` is not on your `PATH`, set the absolute path in settings:
+
+```jsonc
+// settings.json
+"vidyano.path": "/absolute/path/to/vidyano"
+```
+
+## Build the .vsix (sideload)
+
+```bash
+cd editors/vscode
+npm install
+npm run package      # produces vscode-visc-0.1.0.vsix
+```
+
+## Install the .vsix
+
+```bash
+code --install-extension vscode-visc-0.1.0.vsix
+```
+
+Or in VS Code: Extensions view → `…` menu → **Install from VSIX…**.
+
+## Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `vidyano.path` | `""` | Absolute path to the `vidyano` executable. Empty = locate on `PATH`. |
+| `vidyano.trace.server` | `"off"` | LSP trace level (`off` / `messages` / `verbose`). |
+
+## What you get
+
+- Syntax highlighting (TextMate grammar).
+- Live parse/lint diagnostics from `vidyano lsp`.
+- Hover docs for `.visc` verbs.
+
+This is a v1 sideload build — not published to the Marketplace.

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,22 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["(", ")"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    { "open": "(", "close": ")" },
+    { "open": "[", "close": "]" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "{{", "close": "}}" }
+  ],
+  "surroundingPairs": [
+    ["(", ")"],
+    ["[", "]"],
+    ["\"", "\""]
+  ],
+  "autoCloseBefore": ";:.,=}])> \n\t",
+  "wordPattern": "(@?[A-Za-z_][A-Za-z0-9_-]*)"
+}

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,0 +1,2531 @@
+{
+  "name": "vscode-visc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-visc",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "@types/vscode": "^1.85.0",
+        "@vscode/vsce": "^2.24.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.32.0.tgz",
+      "integrity": "sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^6.2.1",
+        "form-data": "^4.0.0",
+        "glob": "^7.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^12.3.2",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.1",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^2.3.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    }
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "vscode-visc",
+  "displayName": "Vidyano Script (.visc)",
+  "description": "Syntax highlighting and language server support for Vidyano .visc scripts.",
+  "version": "0.1.0",
+  "publisher": "vidyano",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/2sky/Vidyano.Core"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:visc"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "visc",
+        "aliases": ["Vidyano Script", "visc"],
+        "extensions": [".visc"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "visc",
+        "scopeName": "source.visc",
+        "path": "./syntaxes/visc.tmLanguage.json"
+      }
+    ],
+    "configuration": {
+      "title": "Vidyano Script",
+      "properties": {
+        "vidyano.path": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Absolute path to the `vidyano` executable. Leave empty to locate `vidyano` on the system `PATH`."
+        },
+        "vidyano.trace.server": {
+          "type": "string",
+          "enum": ["off", "messages", "verbose"],
+          "default": "off",
+          "description": "Trace the communication between VS Code and the .visc language server."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "package": "npx @vscode/vsce package"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/vscode": "^1.85.0",
+    "@vscode/vsce": "^2.24.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,175 @@
+import * as vscode from "vscode";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
+
+const REPO_URL = "https://github.com/2sky/Vidyano.Core";
+const INSTALL_CMD = "dotnet tool install -g Vidyano.Script.Tool";
+const UPDATE_CMD = "dotnet tool update -g Vidyano.Script.Tool";
+
+// Bump this when the extension starts relying on a server capability added in a later tool release.
+// `vidyano lsp` advertises serverInfo.version (>= 5.59.0), so the skew check is live; tools predating
+// that simply report no version and are skipped (see checkVersionSkew).
+const MIN_SERVER_VERSION = "5.59.0";
+
+let client: LanguageClient | undefined;
+let log: vscode.OutputChannel | undefined;
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  log = vscode.window.createOutputChannel("Vidyano Script");
+  context.subscriptions.push(log);
+
+  const cfg = vscode.workspace.getConfiguration("vidyano");
+  const cmd = resolveVidyano(cfg.get<string>("path", "").trim());
+  if (!cmd) {
+    log.appendLine("[activate] Could not locate the 'vidyano' executable (PATH scan and dotnet global-tools dir both failed).");
+    await promptInstall();
+    return;
+  }
+  log.appendLine(`[activate] Using vidyano: ${cmd}`);
+
+  const serverOptions: ServerOptions = {
+    command: cmd,
+    args: ["lsp"],
+    transport: TransportKind.stdio,
+  };
+
+  // Client id "vidyano" makes the v9 client read the `vidyano.trace.server` setting automatically.
+  // Reuse our output channel so activation logs, client logs, and trace all land in one place.
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: "file", language: "visc" }],
+    outputChannel: log,
+    synchronize: {
+      fileEvents: vscode.workspace.createFileSystemWatcher("**/*.visc"),
+    },
+  };
+
+  client = new LanguageClient("vidyano", "Vidyano Script", serverOptions, clientOptions);
+  try {
+    await client.start();
+    log.appendLine("[activate] Language server started.");
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.appendLine(`[activate] Language server failed to start: ${detail}`);
+    log.show(true);
+    void vscode.window.showErrorMessage(
+      `Vidyano: the language server failed to start (${detail}). See the "Vidyano Script" output channel.`,
+    );
+    return;
+  }
+
+  // Best-effort version-skew check (spec Section 7).
+  await checkVersionSkew(client);
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}
+
+// Resolve `vidyano` to an absolute executable path by scanning PATH ourselves. We deliberately do NOT
+// rely on a bare-name spawn: Node's child_process does not apply Windows PATHEXT to a bare command, so
+// `spawn("vidyano")` would ENOENT against the `vidyano.exe` that `dotnet tool install` produces — a false
+// "not found" on Windows. Returning a full path makes the later LanguageClient spawn robust on every OS.
+function resolveVidyano(override: string): string | null {
+  if (override) {
+    // An explicit path: accept it verbatim, or (on Windows) with a PATHEXT extension appended.
+    const hit = (path.isAbsolute(override) || override.includes(path.sep))
+      ? firstExisting(executableCandidates(override))
+      : searchPath(override);
+    log?.appendLine(`[resolve] override "${override}" -> ${hit ?? "not found"}`);
+    return hit;
+  }
+  const onPath = searchPath("vidyano");
+  if (onPath) {
+    log?.appendLine(`[resolve] found on PATH -> ${onPath}`);
+    return onPath;
+  }
+  // Fallback: `dotnet tool install -g` always lands the tool in ~/.dotnet/tools, which is not always on
+  // the editor's PATH (the editor's environment can lag the shell's). Probe that canonical dir directly.
+  const toolsDir = path.join(os.homedir(), ".dotnet", "tools");
+  const canonical = firstExisting(executableCandidates(path.join(toolsDir, "vidyano")));
+  log?.appendLine(`[resolve] PATH miss; dotnet tools dir ${toolsDir} -> ${canonical ?? "not found"}`);
+  return canonical;
+}
+
+// The executable filenames to try for a base name. On Windows a bare name needs an executable extension;
+// mirror cmd.exe by trying each PATHEXT entry (unless the name already carries an extension).
+function executableCandidates(base: string): string[] {
+  if (process.platform !== "win32" || path.extname(base)) {
+    return [base];
+  }
+  const exts = (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean);
+  return exts.map((e) => base + e.toLowerCase());
+}
+
+function searchPath(base: string): string | null {
+  const dirs = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    const hit = firstExisting(executableCandidates(base).map((c) => path.join(dir, c)));
+    if (hit) {
+      return hit;
+    }
+  }
+  return null;
+}
+
+function firstExisting(candidates: string[]): string | null {
+  for (const c of candidates) {
+    if (fs.existsSync(c)) {
+      return c;
+    }
+  }
+  return null;
+}
+
+async function promptInstall(): Promise<void> {
+  const pick = await vscode.window.showErrorMessage(
+    "The 'vidyano' command was not found. Install the Vidyano.Script tool to enable .visc language support.",
+    "Copy install command",
+    "Open docs",
+  );
+  if (pick === "Copy install command") {
+    await vscode.env.clipboard.writeText(INSTALL_CMD);
+    void vscode.window.showInformationMessage(`Copied: ${INSTALL_CMD}`);
+  } else if (pick === "Open docs") {
+    void vscode.env.openExternal(vscode.Uri.parse(REPO_URL));
+  }
+}
+
+async function checkVersionSkew(activeClient: LanguageClient): Promise<void> {
+  // In-band serverInfo.version, advertised by `vidyano lsp` (>= 5.59.0).
+  const reported = activeClient.initializeResult?.serverInfo?.version;
+  if (!reported) {
+    // A tool predating serverInfo.version reports nothing. Silently skip rather than guess — there is
+    // no `vidyano --version` to fall back on (that command does not exist and would exit 64).
+    return;
+  }
+  if (compareSemver(reported, MIN_SERVER_VERSION) < 0) {
+    const pick = await vscode.window.showWarningMessage(
+      `The installed Vidyano.Script tool (${reported}) is older than the minimum supported by this extension (${MIN_SERVER_VERSION}). Some features may not work.`,
+      "Copy update command",
+    );
+    if (pick === "Copy update command") {
+      await vscode.env.clipboard.writeText(UPDATE_CMD);
+      void vscode.window.showInformationMessage(`Copied: ${UPDATE_CMD}`);
+    }
+  }
+}
+
+// Minimal numeric major.minor.patch comparison; ignores pre-release tags (none used in this repo).
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) !== (pb[i] ?? 0)) {
+      return (pa[i] ?? 0) - (pb[i] ?? 0);
+    }
+  }
+  return 0;
+}

--- a/editors/vscode/syntaxes/visc.tmLanguage.json
+++ b/editors/vscode/syntaxes/visc.tmLanguage.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Vidyano Script",
+  "scopeName": "source.visc",
+  "patterns": [
+    { "include": "#step-header" },
+    { "include": "#line-comment" },
+    { "include": "#string" },
+    { "include": "#interpolation" },
+    { "include": "#verb" },
+    { "include": "#sub-keyword" },
+    { "include": "#type-word" },
+    { "include": "#constant" },
+    { "include": "#number" },
+    { "include": "#variable" },
+    { "include": "#operator" },
+    { "include": "#punctuation" }
+  ],
+  "repository": {
+    "step-header": {
+      "match": "^\\s*(###)(.*)$",
+      "captures": {
+        "1": { "name": "punctuation.definition.comment.visc" },
+        "2": { "name": "comment.block.documentation.visc" }
+      }
+    },
+    "line-comment": {
+      "match": "(#).*$",
+      "captures": { "1": { "name": "punctuation.definition.comment.visc" } },
+      "name": "comment.line.number-sign.visc"
+    },
+    "string": {
+      "name": "string.quoted.double.visc",
+      "begin": "\"",
+      "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.visc" } },
+      "end": "\"",
+      "endCaptures": { "0": { "name": "punctuation.definition.string.end.visc" } },
+      "patterns": [
+        { "name": "constant.character.escape.visc", "match": "\\\\[ntr\"\\\\{}]" },
+        { "include": "#interpolation" }
+      ]
+    },
+    "interpolation": {
+      "name": "meta.interpolation.visc",
+      "begin": "\\{\\{",
+      "beginCaptures": { "0": { "name": "punctuation.section.interpolation.begin.visc" } },
+      "end": "\\}\\}",
+      "endCaptures": { "0": { "name": "punctuation.section.interpolation.end.visc" } },
+      "patterns": [
+        { "name": "variable.language.visc", "match": "@(?:today|now|uuid|random)\\b" },
+        { "name": "variable.other.visc", "match": "@[A-Za-z_][A-Za-z0-9_.-]*" },
+        { "name": "support.function.visc", "match": "\\benv\\b" },
+        { "name": "keyword.operator.visc", "match": "\\?\\?|:" },
+        { "include": "#string" }
+      ]
+    },
+    "verb": {
+      "name": "keyword.control.visc",
+      "match": "(?i)(?<![\\w-])(?:SIGN-IN|SIGN-OUT|OPEN-ROW|OPEN-DETAIL|GO-BACK|SELECT-ROWS|OPEN|USE|FOLLOW|EDIT|CANCEL|SAVE|REFRESH|RELOAD|SET|ACTION|SEARCH|EXPECT|GOTO|TOOL|REQUIRES|CLEANUP)(?![\\w-])"
+    },
+    "sub-keyword": {
+      "name": "keyword.other.visc",
+      "match": "(?i)(?<![\\w-])(?:FROM|ENV|LANGUAGE|AS|WHERE|ALL|EXCEPT|NONE|IS|NOT|LOOKUP|ID|MATCHES|CONTAINS|EXPECTING|ERROR|DETAIL|VISIBLE|READONLY|REQUIRED|AVAILABLE)(?![\\w-])"
+    },
+    "type-word": {
+      "name": "support.type.visc",
+      "match": "(?i)(?<![\\w-])(?:PersistentObject|Query|MenuItem|NavStack|TotalItems|Selection|IsInEdit|IsDirty|ClientOperation|NotificationType|Notification|Attribute|TypeHint|Type|Tag|Label|PO)(?![\\w-])"
+    },
+    "constant": {
+      "name": "constant.language.visc",
+      "match": "(?i)(?<![\\w-])(?:true|false|null)(?![\\w-])"
+    },
+    "number": {
+      "name": "constant.numeric.visc",
+      "match": "(?<![\\w.])-?\\d+(?:\\.\\d+)?(?![\\w])"
+    },
+    "variable": {
+      "match": "(@)[A-Za-z_][A-Za-z0-9_-]*",
+      "captures": {
+        "1": { "name": "punctuation.definition.variable.visc" },
+        "0": { "name": "variable.other.visc" }
+      }
+    },
+    "operator": {
+      "name": "keyword.operator.visc",
+      "match": "->|==|!=|<=|>=|=|<|>|/|\\?\\?"
+    },
+    "punctuation": {
+      "name": "punctuation.separator.visc",
+      "match": "[(),\\[\\].]"
+    }
+  }
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## What

Adds **Language Server Protocol support for `.visc` (Vidyano.Script) files** — a static, no-backend language server plus a VS Code extension. Editing a `.visc` file now gives **live diagnostics, verb hover, syntax highlighting, and a step outline**.

## Design

Chosen shape (from a design-exploration pass): a **"common-case + one sink port"** hybrid.

- A pure, OmniSharp-free **`ViscLanguageService`** owns all testable logic — analysis orchestration, the 1-based-char → 0-based-UTF-16 coordinate mapping, `ErrorKind` → severity, and hover — with no protocol type on its hot `DidChange(uri, text)` path.
- An opaque **`ViscLspServer.RunStdioAsync`** owns only JSON-RPC/stdio (OmniSharp), and advertises `serverInfo.version`.
- Exactly **one port, `IDiagnosticSink`**, so the document → publish round-trip (including clearing diagnostics on a now-clean document) is asserted through a real boundary. Speculative seams (`IScriptAnalyzer`, `IDocumentStore`, pluggable providers) were deliberately rejected.

## Single source of truth

A canonical **`VerbCatalog`** now lives in core `Vidyano.Script`. The parser's known-verb gate, `vidyano help verbs`, and LSP hover all render from it — the long-standing drift hazard between those three verb lists is gone.

## Components

- **`Vidyano.Script.LanguageServer`** (new lib): `ViscLanguageService`, `IDiagnosticSink`, `DiagnosticMapper`, `ViscLspServer`. `IsPackable=false` — it ships *inside* the `vidyano` dotnet tool, not as a standalone package.
- **`vidyano lsp`** subcommand hosts the server over stdio.
- **`editors/vscode/`** (new, outside the `.sln`): TextMate grammar (scopes agree with the lexer), `language-configuration.json`, and a `vscode-languageclient` launcher that spawns `vidyano lsp`, with a `vidyano.path` override, a not-found install prompt, an activation-time version-skew check, and output-channel logging. Sideloaded `.vsix` for v1.

## Verification

- ✅ Build green (net8.0 + net10.0), 0 errors
- ✅ **210 tests pass** (incl. `LanguageServerContractTests` covering the document → publish round-trip through the real sink, and `VerbCatalogReconciliationTests` proving the three verb sources collapsed)
- ✅ Extension compiles (`tsc` strict) and packages to a `.vsix`
- ✅ **Diagnostics, hover, and highlighting confirmed live in VS Code** against real `.visc` scripts (verified via a real-pipe LSP probe and the editor itself)

## Try it

```
dotnet tool install -g Vidyano.Script.Tool      # provides `vidyano lsp`
# then sideload editors/vscode (npm run package -> code --install-extension *.vsix)
```

## Deferred (v2 / follow-ups)

- Completion + live/semantic validation (the v2 chapter)
- Visual Studio client (the server speaks vanilla LSP, so VS can attach to the same binary)
- Marketplace publishing (sideload-only for v1)
- Nits: the grammar's hand-curated EXPECT-subject list (drift risk), a shared word-scan helper in `ViscLanguageService`, an ASCII-identifier comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
