### PR TITLE
feat: .visc multi-session — USE / SIGN-OUT / named SIGN-IN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ The repository also ships two scripting packages built on top of Vidyano.Core. T
 |---|---|
 | `SIGN-IN <user> / <pwd>` | Authenticate (optionally `LANGUAGE xx-XX`). |
 | `SIGN-IN FROM ENV` | Authenticate using `VIDYANO_USER` / `VIDYANO_PASSWORD` from the environment (loud-fails when either is unset). Optional `LANGUAGE xx-XX`. |
+| `SIGN-IN @name = <user> / <pwd>` | Open a **named** session (the `=` is required). Mints its OWN cookie jar / identity, so it never shares auth with the default or any other named session. Re-`SIGN-IN @name` re-auths the existing slot in place (no nav-state reset). |
+| `USE @name` | Switch the active session to a named one — all observable state (nav stack, current PO/Query, client operations, `@session`) swaps atomically. Only named sessions are addressable (the default `""` session is unreachable by name); an unknown name fails with `resolve-session` + a suggestion. |
+| `SIGN-OUT` / `SIGN-OUT @name` | Faithful `viSignOut` (real server action + auth clear) against the current (bare) or named session. A named (minted) session is then disposed + removed; the default session is left present-but-disconnected. If the signed-out session was active, the active session falls back to the default slot. |
 | `OPEN MenuItem <path>` | Push a Query frame on the nav stack. |
 | `OPEN-ROW <i>` | Push a PO frame from row `i` of the top Query (by index). |
 | `OPEN-ROW WHERE <col> = <value>` | Push a PO frame from the single row whose `<col>` equals `<value>` — addresses a fixture by reference, not index. Strict: 0 or >1 matches fail. Value is service-string form (same convention as `SET`); only `=` is supported. |

--- a/Vidyano.Script.Tests/DeterminismRuntimeTests.cs
+++ b/Vidyano.Script.Tests/DeterminismRuntimeTests.cs
@@ -38,7 +38,7 @@ public sealed class DeterminismRuntimeTests
         DateTimeOffset? now = null,
         int? seed = null,
         IReadOnlyDictionary<string, ScriptToolHandler>? tools = null) =>
-        new(session, initialVars: null, mode: GuardMode.Navigation, tools: tools, cancellationToken: default,
+        new(TestSessionBook.Wrap(session), initialVars: null, mode: GuardMode.Navigation, tools: tools, cancellationToken: default,
             now: now, seed: seed);
 
     private static List<StatementResult> Statements(ScriptResult result) =>

--- a/Vidyano.Script.Tests/EnvSourcingTests.cs
+++ b/Vidyano.Script.Tests/EnvSourcingTests.cs
@@ -38,7 +38,7 @@ public sealed class EnvSourcingTests
         IDictionary<string, string?> env,
         IReadOnlyDictionary<string, object?>? initialVars = null,
         string? envPrefix = null) =>
-        new(session, initialVars: initialVars, mode: GuardMode.Navigation, tools: null,
+        new(TestSessionBook.Wrap(session), initialVars: initialVars, mode: GuardMode.Navigation, tools: null,
             cancellationToken: default, now: null, seed: null,
             envLookup: name => env.TryGetValue(name, out var v) ? v : null,
             envPrefix: envPrefix);

--- a/Vidyano.Script.Tests/SessionBookTests.cs
+++ b/Vidyano.Script.Tests/SessionBookTests.cs
@@ -1,0 +1,381 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Vidyano.Script.Diagnostics;
+using Vidyano.Script.Parsing;
+using Vidyano.Script.Runtime;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// The multi-identity contract of <see cref="SessionBook"/> and its three interpreter verbs
+/// (<c>SIGN-IN @name</c> / <c>USE @name</c> / <c>SIGN-OUT [@name]</c>). Everything here is
+/// server-free: <see cref="SessionBook"/> is exercised directly with a counting/tracking fake
+/// <c>mintFresh</c> for the map/collision/disposal invariants, and the loud-failure name-miss paths
+/// are also driven through <see cref="Interpreter.RunAsync"/> on real <c>.visc</c> source to prove
+/// the verb wiring. <see cref="Vidyano.Client.SignOut"/> only touches the network when an
+/// Application is present (after a real sign-in), so calling it on a never-signed-in session against
+/// an unreachable host is a pure local-state clear — safe in CI.
+/// </summary>
+public sealed class SessionBookTests
+{
+    private const string UnreachableHost = "https://127.0.0.1:1";
+    private static readonly SourceLocation Loc = SourceLocation.Unknown;
+
+    /// <summary>An own-jar session against the unreachable host — identical to what the production
+    /// <c>mintFresh</c> builds (the cookie-jar trap ctor branch: <c>httpClient: null</c>).</summary>
+    private static VidyanoSession NewOwnJarSession() =>
+        new(UnreachableHost, acceptAnyServerCertificate: true);
+
+    /// <summary>A <c>mintFresh</c> that records every invocation and the instances it handed back, so
+    /// tests can assert call counts (collision rule) and disposal ownership.</summary>
+    private sealed class MintTracker
+    {
+        public int Calls { get; private set; }
+        public List<VidyanoSession> Minted { get; } = new();
+
+        public Func<ValueTask<VidyanoSession>> Factory => () =>
+        {
+            Calls++;
+            var s = NewOwnJarSession();
+            Minted.Add(s);
+            return new ValueTask<VidyanoSession>(s);
+        };
+    }
+
+    private static ScriptAst Parse(string body)
+    {
+        var lexer = new Lexer(body, "<test>");
+        var tokens = lexer.Tokenize();
+        var parser = new Parser(tokens, lexer.Diagnostics);
+        var ast = parser.Parse();
+        Assert.True(parser.Diagnostics.Count == 0,
+            $"Parse errors: {string.Join("; ", parser.Diagnostics.Select(d => d.Message))}");
+        return ast;
+    }
+
+    private static List<StatementResult> Statements(ScriptResult result) =>
+        result.Steps.SelectMany(s => s.Statements).ToList();
+
+    // --- the "" default floor: zero-cost single session, mintFresh never touched ----------------
+
+    [Fact]
+    public async Task DefaultSlot_SignIn_NeverMints()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        // A null/empty name selects the "" floor and mints nothing — the single-session path.
+        var slot = await book.SignInSlotAsync(null);
+
+        Assert.True(slot.Ok);
+        Assert.Same(initial, slot.Value);
+        Assert.Same(initial, book.Current);
+        Assert.Equal(0, tracker.Calls);
+    }
+
+    [Fact]
+    public void DefaultSlot_IsCurrentBeforeAnySignIn()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        // The "" floor keeps Current non-null for the whole script life, even before any verb runs.
+        Assert.Same(initial, book.Current);
+    }
+
+    // --- USE @unknown / SIGN-OUT @unknown: loud, non-throwing failure ---------------------------
+
+    [Fact]
+    public void Use_UnknownName_FailsWithResolveSession_DoesNotThrow()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var res = book.Use("ghost", Loc);
+
+        Assert.False(res.Ok);
+        Assert.NotNull(res.Error);
+        Assert.Equal(ErrorKind.ResolveSession, res.Error!.Kind);
+        // A name miss must not move the pointer off the floor.
+        Assert.Same(initial, book.Current);
+    }
+
+    [Fact]
+    public async Task SignOut_UnknownName_FailsWithResolveSession_DoesNotThrow()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var res = await book.SignOut("ghost", Loc);
+
+        Assert.False(res.Ok);
+        Assert.NotNull(res.Error);
+        Assert.Equal(ErrorKind.ResolveSession, res.Error!.Kind);
+    }
+
+    [Fact]
+    public async Task Use_UnknownName_OffersHintOverKnownSlots()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+        await book.SignInSlotAsync("admin");
+
+        // "admni" is one transposition from the known "admin" — the Suggester should propose it.
+        var res = book.Use("admni", Loc);
+
+        Assert.False(res.Ok);
+        Assert.NotNull(res.Error!.Hint);
+        Assert.Contains("admin", res.Error.Hint!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UseUnknown_ThroughInterpreter_FailsLoudly_DoesNotThrow()
+    {
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, () => new ValueTask<VidyanoSession>(NewOwnJarSession()));
+        var interp = new Interpreter(book);
+
+        var result = await interp.RunAsync(Parse("USE @ghost"));
+
+        var stmt = Statements(result).Single();
+        Assert.False(stmt.Ok);
+        Assert.Equal(ErrorKind.ResolveSession, stmt.Diagnostics.Single().Kind);
+    }
+
+    [Fact]
+    public async Task SignOutUnknown_ThroughInterpreter_FailsLoudly_DoesNotThrow()
+    {
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, () => new ValueTask<VidyanoSession>(NewOwnJarSession()));
+        var interp = new Interpreter(book);
+
+        var result = await interp.RunAsync(Parse("SIGN-OUT @ghost"));
+
+        var stmt = Statements(result).Single();
+        Assert.False(stmt.Ok);
+        Assert.Equal(ErrorKind.ResolveSession, stmt.Diagnostics.Single().Kind);
+    }
+
+    // --- distinct named slots: pointer-flip isolation -------------------------------------------
+
+    [Fact]
+    public async Task TwoNamedSignIns_YieldDistinctSessions()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var a = await book.SignInSlotAsync("a");
+        var b = await book.SignInSlotAsync("b");
+
+        Assert.True(a.Ok && b.Ok);
+        Assert.NotSame(initial, a.Value);
+        Assert.NotSame(initial, b.Value);
+        Assert.NotSame(a.Value, b.Value);
+        Assert.Equal(2, tracker.Calls);
+    }
+
+    [Fact]
+    public async Task Use_SwitchesCurrentBetweenNamedSlots()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var a = (await book.SignInSlotAsync("a")).Value;
+        var b = (await book.SignInSlotAsync("b")).Value; // b is current after its sign-in
+        Assert.Same(b, book.Current);
+
+        var useA = book.Use("a", Loc);
+        Assert.True(useA.Ok);
+        Assert.Same(a, book.Current);
+
+        var useB = book.Use("b", Loc);
+        Assert.True(useB.Ok);
+        Assert.Same(b, book.Current);
+        // Switching never mints — both slots already exist.
+        Assert.Equal(2, tracker.Calls);
+    }
+
+    // --- collision rule: repeat SIGN-IN @name reuses the slot, never re-mints -------------------
+
+    [Fact]
+    public async Task RepeatNamedSignIn_ReusesSameSession_DoesNotReMint()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var first = await book.SignInSlotAsync("a");
+        var second = await book.SignInSlotAsync("a");
+
+        Assert.Same(first.Value, second.Value);
+        // mintFresh must run exactly once for the name — the collision re-auths in place.
+        Assert.Equal(1, tracker.Calls);
+    }
+
+    [Fact]
+    public async Task NameMatching_IsCaseInsensitive()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var lower = await book.SignInSlotAsync("admin");
+        var upper = await book.SignInSlotAsync("ADMIN");
+
+        // OrdinalIgnoreCase keying: the second sign-in hits the same slot, no second mint.
+        Assert.Same(lower.Value, upper.Value);
+        Assert.Equal(1, tracker.Calls);
+
+        // USE resolves the same slot regardless of case.
+        Assert.True(book.Use("Admin", Loc).Ok);
+        Assert.Same(lower.Value, book.Current);
+    }
+
+    // --- SIGN-OUT of a named slot: dispose + remove + repoint to the "" floor -------------------
+
+    [Fact]
+    public async Task SignOutCurrentNamedSlot_RepointsToDefaultFloor_AndRemovesSlot()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        await book.SignInSlotAsync("a");
+        Assert.NotSame(initial, book.Current);
+
+        var bare = await book.SignOut(null, Loc); // bare = the current slot, which is @a
+        Assert.True(bare.Ok);
+
+        // The minted slot is gone; Current falls back to the "" floor.
+        Assert.Same(initial, book.Current);
+        // It is fully removed from the map: USE @a now misses.
+        Assert.False(book.Use("a", Loc).Ok);
+    }
+
+    [Fact]
+    public async Task SignOutNamedSlot_WhileADifferentSlotIsCurrent_LeavesCurrentUntouched()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        await book.SignInSlotAsync("a");
+        var b = (await book.SignInSlotAsync("b")).Value; // b current
+
+        var res = await book.SignOut("a", Loc); // sign out the non-current slot by name
+        Assert.True(res.Ok);
+
+        // Signing out a non-current slot must not move the pointer.
+        Assert.Same(b, book.Current);
+        Assert.False(book.Use("a", Loc).Ok);
+        Assert.True(book.Use("b", Loc).Ok);
+    }
+
+    [Fact]
+    public async Task SignOutDefaultFloor_LeavesItPresentButDisconnected()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        // Bare SIGN-OUT while the "" floor is current targets it; the floor is never removed/disposed.
+        var res = await book.SignOut(null, Loc);
+
+        Assert.True(res.Ok);
+        Assert.Same(initial, book.Current); // still the same instance, still present
+        Assert.False(initial.IsSignedIn);   // but disconnected after the local-state clear
+    }
+
+    // --- disposal ownership split: book disposes MINTED slots, never the initial ----------------
+
+    [Fact]
+    public async Task SignOutNamedSlot_DisposesItsOwnedTransport()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var minted = (await book.SignInSlotAsync("a")).Value!;
+        await book.SignOut("a", Loc);
+
+        // A minted slot owns its HttpClient; the book must dispose it on sign-out. A disposed
+        // owned-jar session can no longer issue requests — TakeSnapshot stays safe, but a transport
+        // attempt throws ObjectDisposedException. Probe via the disposed client.
+        Assert.True(IsOwnedTransportDisposed(minted),
+            "SIGN-OUT of a minted slot must dispose its owned HttpClient.");
+    }
+
+    [Fact]
+    public async Task Dispose_DisposesMintedSlots_ButNotInitial()
+    {
+        var tracker = new MintTracker();
+        var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+
+        var m1 = (await book.SignInSlotAsync("a")).Value!;
+        var m2 = (await book.SignInSlotAsync("b")).Value!;
+
+        book.Dispose();
+
+        Assert.True(IsOwnedTransportDisposed(m1), "Dispose() must dispose minted slot @a.");
+        Assert.True(IsOwnedTransportDisposed(m2), "Dispose() must dispose minted slot @b.");
+        // The caller-supplied initial slot is owned by the runner, NOT the book — it must survive.
+        Assert.False(IsOwnedTransportDisposed(initial),
+            "Dispose() must NOT dispose the caller-owned initial slot.");
+
+        initial.Dispose(); // clean up the one the book intentionally left alone
+    }
+
+    /// <summary>True if the session's own-jar <c>HttpClient</c> (the <c>_ownedHttpClient</c> the
+    /// cookie-jar ctor branch builds) has been disposed. <see cref="VidyanoSession.Dispose"/> disposes
+    /// only that field, and a disposed <c>HttpClient</c> throws <see cref="ObjectDisposedException"/>
+    /// synchronously from <c>CancelPendingRequests()</c> with no network — so this distinguishes
+    /// "book disposed it" from "book left it alone" deterministically. Read through reflection because
+    /// the owned transport is intentionally private (the abstraction hides it); the test asserts the
+    /// disposal-ownership invariant, which has no public observable on the sealed session.</summary>
+    private static bool IsOwnedTransportDisposed(VidyanoSession session)
+    {
+        var field = typeof(VidyanoSession).GetField("_ownedHttpClient",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var http = (HttpClient?)field!.GetValue(session);
+        Assert.NotNull(http); // an own-jar session always has one; a supplied-client session would not
+        try
+        {
+            http!.CancelPendingRequests();
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    // --- regression: through the interpreter, the single-session path is unchanged --------------
+
+    [Fact]
+    public async Task SingleSessionScript_RunsWithoutMinting()
+    {
+        var tracker = new MintTracker();
+        using var initial = NewOwnJarSession();
+        var book = new SessionBook(initial, tracker.Factory);
+        var interp = new Interpreter(book);
+
+        // A server-free script that never names a session: the "" floor carries it; mintFresh stays cold.
+        var result = await interp.RunAsync(Parse("@x = 1\nEXPECT {{x}} = 1"));
+
+        Assert.True(result.Ok, result.Describe());
+        Assert.Equal(0, tracker.Calls);
+    }
+}

--- a/Vidyano.Script.Tests/StringInterpolationTests.cs
+++ b/Vidyano.Script.Tests/StringInterpolationTests.cs
@@ -31,7 +31,7 @@ public sealed class StringInterpolationTests
         new("https://127.0.0.1:1", acceptAnyServerCertificate: true);
 
     private static Interpreter NewInterpreter(DateTimeOffset? now = null, int? seed = null) =>
-        new(NewSession(), initialVars: null, mode: GuardMode.Navigation, tools: null, cancellationToken: default,
+        new(TestSessionBook.Wrap(NewSession()), initialVars: null, mode: GuardMode.Navigation, tools: null, cancellationToken: default,
             now: now, seed: seed);
 
     private static string Var(Interpreter interp, string name) =>

--- a/Vidyano.Script.Tests/TestSessionBook.cs
+++ b/Vidyano.Script.Tests/TestSessionBook.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Vidyano.Script.Runtime;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Test helpers for wrapping a <see cref="VidyanoSession"/> in a <see cref="SessionBook"/> — the
+/// interpreter now takes a book, not a bare session. The server-free tests only ever hit the
+/// default ("") slot, so a <c>mintFresh</c> that hands back fresh own-jar sessions against the same
+/// unreachable host is all they need.
+/// </summary>
+internal static class TestSessionBook
+{
+    private const string UnreachableHost = "https://127.0.0.1:1";
+
+    /// <summary>Wraps an existing session as the default slot of a book whose <c>mintFresh</c> spins up
+    /// further own-jar sessions against the same unreachable host (never exercised in server-free tests).</summary>
+    public static SessionBook Wrap(VidyanoSession initial) =>
+        new(initial, () => new ValueTask<VidyanoSession>(
+            new VidyanoSession(UnreachableHost, acceptAnyServerCertificate: true)));
+}

--- a/Vidyano.Script.Tool/README.md
+++ b/Vidyano.Script.Tool/README.md
@@ -110,6 +110,25 @@ EXPECT PO.Metadata.brand = "vidyano"
 EXPECT Query.Columns[FirstName].Label = "First name"
 ```
 
+### Multiple identities in one script
+
+Naming a session opts into multi-identity — each named session mints its **own** cookie jar, so an admin and a tenant never share auth. The default (unnamed) session stays the zero-cost single-session convenience.
+
+```visc
+SIGN-IN @admin = admin / pass            ## the `=` is required for a named session
+SIGN-IN @tenant = guest / pass           ## own cookie jar = distinct identity
+USE @admin                               ## flip the active session; all state swaps atomically
+OPEN MenuItem Home/Customers
+ACTION Delete                            ## runs with @admin's permissions
+USE @tenant
+ACTION Delete EXPECTING ERROR            ## @tenant can't — its permissions never leaked
+SIGN-OUT @tenant                         ## faithful viSignOut, disposed; active falls back to default
+```
+
+- Only **named** sessions are addressable by `USE` — name every session you switch between.
+- Re-`SIGN-IN @name` re-authenticates the existing session in place (no nav-state reset). For a clean slate, `SIGN-OUT @name` then `SIGN-IN @name`.
+- An unknown `USE @name` / `SIGN-OUT @name` is a `resolve-session` diagnostic with a "did you mean" suggestion — it never throws.
+
 ### Deterministic regression scripts
 
 So a checked-in script passes on any machine, it can gate itself and pin its own randomness:

--- a/Vidyano.Script.Tool/ReplCommand.cs
+++ b/Vidyano.Script.Tool/ReplCommand.cs
@@ -54,8 +54,11 @@ public static class ReplCommand
         // The default ("") slot is the REPL's connection; named SIGN-INs mint their own cookie jar via
         // the VidyanoSession own-jar ctor branch (never closing over a shared client) so identities stay
         // isolated. :snapshot reads sessions.Current, so it reflects whatever USE selected.
+        // The REPL owns the default slot's transport (own-jar ctor), so dispose it explicitly —
+        // SessionBook never disposes the caller-supplied `initial`.
+        using var initialSession = new VidyanoSession(a.AppUri, acceptAnyServerCertificate: a.Insecure);
         using var sessions = new SessionBook(
-            initial: new VidyanoSession(a.AppUri, acceptAnyServerCertificate: a.Insecure),
+            initial: initialSession,
             mintFresh: () => new ValueTask<VidyanoSession>(
                 new VidyanoSession(a.AppUri, acceptAnyServerCertificate: a.Insecure)));
         var interpreter = new Interpreter(sessions, options.Variables, a.Mode ?? GuardMode.Navigation, options.Tools, now: options.Now, seed: options.Seed, envLookup: options.EnvLookup, envPrefix: options.EnvironmentPrefix);

--- a/Vidyano.Script.Tool/ReplCommand.cs
+++ b/Vidyano.Script.Tool/ReplCommand.cs
@@ -51,8 +51,14 @@ public static class ReplCommand
             }
         }
 
-        using var session = new VidyanoSession(a.AppUri, acceptAnyServerCertificate: a.Insecure);
-        var interpreter = new Interpreter(session, options.Variables, a.Mode ?? GuardMode.Navigation, options.Tools, now: options.Now, seed: options.Seed, envLookup: options.EnvLookup, envPrefix: options.EnvironmentPrefix);
+        // The default ("") slot is the REPL's connection; named SIGN-INs mint their own cookie jar via
+        // the VidyanoSession own-jar ctor branch (never closing over a shared client) so identities stay
+        // isolated. :snapshot reads sessions.Current, so it reflects whatever USE selected.
+        using var sessions = new SessionBook(
+            initial: new VidyanoSession(a.AppUri, acceptAnyServerCertificate: a.Insecure),
+            mintFresh: () => new ValueTask<VidyanoSession>(
+                new VidyanoSession(a.AppUri, acceptAnyServerCertificate: a.Insecure)));
+        var interpreter = new Interpreter(sessions, options.Variables, a.Mode ?? GuardMode.Navigation, options.Tools, now: options.Now, seed: options.Seed, envLookup: options.EnvLookup, envPrefix: options.EnvironmentPrefix);
 
         AnsiConsole.MarkupLine($"[bold]vidyano repl[/] — connected to [green]{Markup.Escape(a.AppUri)}[/]");
         AnsiConsole.MarkupLine("[grey]Type a .visc line at the prompt. ':help' lists commands. ':save <path>' to write history. Ctrl-C exits.[/]");
@@ -70,7 +76,7 @@ public static class ReplCommand
             // Meta commands
             if (trimmed.StartsWith(':'))
             {
-                if (!await HandleMeta(trimmed, history, interpreter, session).ConfigureAwait(false)) break;
+                if (!await HandleMeta(trimmed, history, interpreter, sessions).ConfigureAwait(false)) break;
                 continue;
             }
 
@@ -101,7 +107,7 @@ public static class ReplCommand
         return Cli.ExitOk;
     }
 
-    private static Task<bool> HandleMeta(string cmd, List<string> history, Interpreter interpreter, VidyanoSession session)
+    private static Task<bool> HandleMeta(string cmd, List<string> history, Interpreter interpreter, SessionBook sessions)
     {
         // Returns false to exit the REPL.
         var parts = cmd.Split(' ', 2);
@@ -125,7 +131,7 @@ public static class ReplCommand
                 return Task.FromResult(true);
             case ":snapshot":
                 {
-                    var snap = session.TakeSnapshot();
+                    var snap = sessions.Current.TakeSnapshot();
                     System.Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(snap,
                         new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
                     return Task.FromResult(true);

--- a/Vidyano.Script.Tool/samples/sessions.visc
+++ b/Vidyano.Script.Tool/samples/sessions.visc
@@ -1,0 +1,70 @@
+### Multi-session — named sessions, USE, SIGN-OUT, and per-session isolation.
+###
+### This file lints cleanly with no backend. The executable portion runs against the public demo
+### and proves the multi-session MECHANICS using one credential pair in two NAMED sessions: naming
+### a session mints its OWN cookie jar, so two named sessions are independent identities even when
+### the user is the same. The admin-vs-tenant PERMISSION-split use case needs a two-user app, so it
+### is shown commented at the end.
+###
+### Locked semantics (see the package READMEs / `vidyano help verbs`):
+###   • SIGN-IN @name = <user> / <pwd>  — the `=` is REQUIRED; mints a distinct cookie jar / identity.
+###   • USE @name                        — flips the active session; the whole observable state
+###                                        (nav stack, current PO/Query, client ops, @session) swaps.
+###   • Only NAMED sessions are addressable — the default (unnamed) session is unreachable by name,
+###                                        so name every session you intend to switch between.
+###   • Re-SIGN-IN @name                 — re-auths the existing slot in place (no nav-state reset).
+###   • SIGN-OUT [@name]                 — faithful viSignOut; a minted session is disposed + removed;
+###                                        the active session then falls back to the default slot.
+
+@app = "https://demo.vidyano.com"
+
+### Two named sessions over the same credentials — each mints its OWN cookie jar, so they are
+### distinct identities. (A real admin-vs-tenant flow would use two different users — see the bottom.)
+SIGN-IN @admin = admin / admin
+SIGN-IN @second = admin / admin
+
+### Open a Query under @admin.
+USE @admin
+OPEN MenuItem Customers
+EXPECT NavStack.Depth = 1
+EXPECT NavStack.Top.Kind = "Query"
+
+### Switch to @second — its navigation stack is independent (still empty). This is the atomic
+### per-session swap: nothing from @admin's frame leaks across the cookie-jar boundary.
+USE @second
+EXPECT NavStack.Depth = 0
+
+### Switch back — @admin still holds its frame.
+USE @admin
+EXPECT NavStack.Depth = 1
+EXPECT NavStack.Top.Kind = "Query"
+
+### SIGN-OUT a named (minted) session: faithful viSignOut, then disposed + removed. @second was not
+### the active session, so @admin stays active and keeps its frame.
+SIGN-OUT @second
+EXPECT NavStack.Depth = 1
+
+### An unknown name never throws — it is a resolve-session diagnostic with a "did you mean" hint.
+### Uncomment to watch it fail loudly (@second is gone after the SIGN-OUT above):
+# USE @second
+
+### --- Re-SIGN-IN re-auths in place (no nav-state reset) — illustrative -------------------------
+### Re-signing-in an existing named slot re-authenticates it WITHOUT resetting its nav stack; for a
+### clean slate, SIGN-OUT then SIGN-IN. (Depends on a live re-auth, so shown commented.)
+# SIGN-IN @admin = admin / admin
+# EXPECT NavStack.Depth = 1            ## still 1 — re-auth preserved the frame
+
+### --- Permission split (needs a two-user app; illustrative) ------------------------------------
+### The real reason for multi-session: assert that one identity can do what another cannot, in a
+### single script, with no auth bleed between them.
+# SIGN-IN @admin  = admin  / adminpass
+# SIGN-IN @tenant = tenant / tenantpass
+# USE @admin
+# OPEN MenuItem Home/Customers
+# SELECT-ROWS 0
+# ACTION Delete                   ## admin may delete
+# USE @tenant
+# OPEN MenuItem Home/Customers
+# SELECT-ROWS 0
+# ACTION Delete EXPECTING ERROR   ## tenant may NOT — its permissions never leaked from @admin
+# SIGN-OUT @tenant                ## disposed; the active session falls back to the default slot

--- a/Vidyano.Script/Diagnostics/VerbCatalog.cs
+++ b/Vidyano.Script/Diagnostics/VerbCatalog.cs
@@ -38,21 +38,31 @@ public static class VerbCatalog
             "Authenticate against the service.",
             "Authenticate against the Vidyano service. `SIGN-IN FROM ENV` reads `VIDYANO_USER` / "
             + "`VIDYANO_PASSWORD` from the environment and loud-fails if either is unset. The `@name =` "
-            + "form opens a named session.",
+            + "form (the `=` is required) opens a NAMED session that mints its own cookie jar / identity, "
+            + "so it never shares auth with the default session or any other named one. Re-`SIGN-IN @name` "
+            + "re-authenticates the existing slot in place — it does NOT reset its navigation state.",
             ["SIGN-IN admin / admin", "SIGN-IN @admin = user / pwd", "SIGN-IN FROM ENV"],
             "session", []),
 
         new("SIGN-OUT",
-            "SIGN-OUT",
-            "End the current session.",
-            null,
-            ["SIGN-OUT"],
+            "SIGN-OUT\nSIGN-OUT @name",
+            "End the current (or a named) session.",
+            "Performs a faithful `viSignOut` (the real server action plus auth clear) against the target "
+            + "session — the current one for bare `SIGN-OUT`, or the named slot for `SIGN-OUT @name`. A "
+            + "named (minted) session is then disposed and removed; the default session is left present "
+            + "but disconnected (the next verb fails loudly with not-signed-in). When the signed-out "
+            + "session was the active one, the active session falls back to the default slot.",
+            ["SIGN-OUT", "SIGN-OUT @admin"],
             "session", []),
 
         new("USE",
             "USE @name",
-            "Switch to a named session (multi-session not yet implemented).",
-            null,
+            "Switch the active session to a named one.",
+            "Flips the active session to the named slot — all observable state (navigation stack, current "
+            + "PO/Query, client operations, scoped `@session`) swaps atomically. Only NAMED sessions are "
+            + "addressable; the default session is unreachable by name, so name every session you switch "
+            + "between. An unknown name fails with a `resolve-session` diagnostic and a \"did you mean\" "
+            + "suggestion over the open names.",
             ["USE @admin"],
             "session", []),
 

--- a/Vidyano.Script/README.md
+++ b/Vidyano.Script/README.md
@@ -46,7 +46,9 @@ Console.WriteLine(result.Ok ? "PASS" : result.Describe());
 
 A `.visc` script is a sequence of **verbs** that drive a Vidyano session, with **EXPECT** assertions checking observable state at each step. Verbs map 1:1 to user actions a frontend would perform:
 
-- `SIGN-IN <user> / <password>` — authenticate. `SIGN-IN FROM ENV` reads `VIDYANO_USER` / `VIDYANO_PASSWORD` from the environment instead (loud-fails if either is unset).
+- `SIGN-IN <user> / <password>` — authenticate. `SIGN-IN FROM ENV` reads `VIDYANO_USER` / `VIDYANO_PASSWORD` from the environment instead (loud-fails if either is unset). `SIGN-IN @name = <user> / <password>` (the `=` is required) opens a **named** session that mints its own cookie jar / identity — so admin-vs-tenant permission flows never share auth.
+- `USE @name` — switch the active session to a named one. All observable state (nav stack, current PO/Query, client operations, `@session`) swaps atomically. Only named sessions are addressable — the default session is unreachable by name, so name every session you switch between. An unknown name fails with a `resolve-session` diagnostic and a suggestion.
+- `SIGN-OUT` / `SIGN-OUT @name` — faithful `viSignOut` (real server action + auth clear) against the current (bare) or named session. A named (minted) session is then disposed and removed; the default session is left present-but-disconnected. If the signed-out session was active, the active session falls back to the default slot. Re-`SIGN-IN @name` re-authenticates an existing named session in place and does **not** reset its nav state — to get a clean slate, `SIGN-OUT @name` then `SIGN-IN @name`.
 - `OPEN MenuItem <path>` — navigate to a query.
 - `OPEN-ROW <index>` — drill into a row by position.
 - `OPEN-ROW WHERE <column> = <value>` — drill into the single row matched by a column value (strict — 0 or >1 matches fail; value in service-string form, like `SET`). Addresses a fixture by reference instead of a brittle row index.

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -18,7 +18,8 @@ namespace Vidyano.Script.Runtime;
 /// </summary>
 public sealed class Interpreter
 {
-    private readonly VidyanoSession _session;
+    private readonly SessionBook _sessions;
+    private VidyanoSession Current => _sessions.Current;
     private readonly Dictionary<string, object?> _vars;
     private readonly Func<string, string?> _envLookup;
     private readonly IReadOnlyDictionary<string, ScriptToolHandler> _tools;
@@ -38,8 +39,11 @@ public sealed class Interpreter
     private Random _uuidRng = null!;
     private Random _randomRng = null!;
 
-    public Interpreter(
-        VidyanoSession session,
+    // internal: the ctor takes the internal SessionBook. The three construction sites — the
+    // VidyanoScript façade (same assembly), ReplCommand, and the test project — reach it via
+    // InternalsVisibleTo (declared in SessionBook.cs). The public running surface stays VidyanoScript.
+    internal Interpreter(
+        SessionBook sessions,
         IReadOnlyDictionary<string, object?>? initialVars = null,
         GuardMode mode = GuardMode.Navigation,
         IReadOnlyDictionary<string, ScriptToolHandler>? tools = null,
@@ -49,7 +53,7 @@ public sealed class Interpreter
         Func<string, string?>? envLookup = null,
         string? envPrefix = null)
     {
-        _session = session;
+        _sessions = sessions;
         _vars = initialVars is null
             ? new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, object?>(initialVars, StringComparer.OrdinalIgnoreCase);
@@ -142,14 +146,14 @@ public sealed class Interpreter
         // EXPECT — assertions consume what the *previous* verb produced). Meta statements
         // (@var, @mode) don't talk to the server, so they leave the buffer alone too.
         if (!isMetaStmt && stmt is not ExpectStmt)
-            _session.ResetLastOperations();
+            Current.ResetLastOperations();
 
         // Initial-PO gate: while Client.Initial is non-null the script is "frozen" against the
         // gate, matching the spec ("Until @initial == null, non-initial verbs error with
         // state-initial-pending"). Only meta statements, SAVE @initial, and EXPECTs that
         // observe the @initial scope are allowed through. `@mode = direct` is the documented
         // escape hatch. Lint never sees this — the guard requires a live Client.Initial.
-        if (!isMetaStmt && _mode != GuardMode.Direct && _session.Client.Initial is not null
+        if (!isMetaStmt && _mode != GuardMode.Direct && Current.Client.Initial is not null
             && !IsInitialScoped(stmt))
         {
             return Fail(stmt, new Diagnostic(
@@ -179,24 +183,24 @@ public sealed class Interpreter
                     return Ok(stmt);
                 }
             case SignInStmt si:                return await DoSignIn(si).ConfigureAwait(false);
-            case UseSessionStmt us:            return Fail(stmt, new Diagnostic(ErrorKind.ResolveSession, "Multi-session is not implemented in this build.", us.Location));
-            case SignOutStmt so:               return Fail(stmt, new Diagnostic(ErrorKind.ResolveSession, "SIGN-OUT is not implemented in this build.", so.Location));
+            case UseSessionStmt us:            return Wrap(stmt, _sessions.Use(us.SessionName, us.Location));
+            case SignOutStmt so:               return Wrap(stmt, await _sessions.SignOut(so.SessionName, so.Location).ConfigureAwait(false));
             case OpenPersistentObjectStmt op:  return await DoOpenPo(op).ConfigureAwait(false);
             case OpenQueryStmt oq:             return await DoOpenQuery(oq).ConfigureAwait(false);
             case OpenMenuItemStmt om:          return await DoOpenMenu(om).ConfigureAwait(false);
             case OpenRowStmt or:               return await DoOpenRow(or).ConfigureAwait(false);
             case SelectRowsStmt sr:            return await DoSelectRows(sr).ConfigureAwait(false);
-            case GoBackStmt gb:                return Wrap(stmt, _session.GoBack(gb.Location));
-            case EditStmt e:                   return Wrap(stmt, _session.Edit(e.Location));
-            case CancelStmt c:                 return Wrap(stmt, _session.Cancel(c.Location));
+            case GoBackStmt gb:                return Wrap(stmt, Current.GoBack(gb.Location));
+            case EditStmt e:                   return Wrap(stmt, Current.Edit(e.Location));
+            case CancelStmt c:                 return Wrap(stmt, Current.Cancel(c.Location));
             case SaveStmt sv:
                 {
                     var saveRes = string.Equals(sv.Scope, "initial", StringComparison.OrdinalIgnoreCase)
-                        ? await _session.SaveInitialAsync(sv.Location).ConfigureAwait(false)
-                        : await _session.SaveAsync(sv.Location).ConfigureAwait(false);
+                        ? await Current.SaveInitialAsync(sv.Location).ConfigureAwait(false)
+                        : await Current.SaveAsync(sv.Location).ConfigureAwait(false);
                     return sv.ExpectError ? WrapExpectingError(stmt, saveRes) : Wrap(stmt, saveRes);
                 }
-            case RefreshStmt rf:               return Wrap(stmt, await _session.RefreshAsync(rf.Location).ConfigureAwait(false));
+            case RefreshStmt rf:               return Wrap(stmt, await Current.RefreshAsync(rf.Location).ConfigureAwait(false));
             case SetStmt s:                    return await DoSet(s).ConfigureAwait(false);
             case ActionStmt a:                 return await DoAction(a).ConfigureAwait(false);
             case SearchStmt q:                 return await DoSearch(q).ConfigureAwait(false);
@@ -261,7 +265,11 @@ public sealed class Interpreter
             if (!lang.Ok) return Fail(si, lang.Error!);
             language = AsString(lang.Value);
         }
-        var res = await _session.SignInAsync(userName, password, language, si.Location).ConfigureAwait(false);
+        // Select (and, for a new named slot, mint) the target session before authenticating. A
+        // null/empty name is the default "" slot (mints nothing); a named slot is minted-or-reused.
+        var slot = await _sessions.SignInSlotAsync(si.SessionName).ConfigureAwait(false);
+        if (!slot.Ok) return Fail(si, slot.Error!);
+        var res = await Current.SignInAsync(userName, password, language, si.Location).ConfigureAwait(false);
         return Wrap(si, res);
     }
 
@@ -282,7 +290,7 @@ public sealed class Interpreter
             if (!o.Ok) return Fail(op, o.Error!);
             oid = AsString(o.Value);
         }
-        var res = await _session.OpenPersistentObjectAsync(AsString(t.Value), oid, op.AsHandle, op.Location).ConfigureAwait(false);
+        var res = await Current.OpenPersistentObjectAsync(AsString(t.Value), oid, op.AsHandle, op.Location).ConfigureAwait(false);
         return Wrap(op, res);
     }
 
@@ -290,7 +298,7 @@ public sealed class Interpreter
     {
         var t = EvaluateExpression(oq.Id);
         if (!t.Ok) return Fail(oq, t.Error!);
-        var res = await _session.OpenQueryAsync(AsString(t.Value), oq.AsHandle, oq.Location).ConfigureAwait(false);
+        var res = await Current.OpenQueryAsync(AsString(t.Value), oq.AsHandle, oq.Location).ConfigureAwait(false);
         return Wrap(oq, res);
     }
 
@@ -303,7 +311,7 @@ public sealed class Interpreter
             if (!v.Ok) return Fail(om, v.Error!);
             segments.Add(AsString(v.Value));
         }
-        var res = await _session.OpenMenuItemAsync(segments, om.AsHandle, om.Location).ConfigureAwait(false);
+        var res = await Current.OpenMenuItemAsync(segments, om.AsHandle, om.Location).ConfigureAwait(false);
         return Wrap(om, res);
     }
 
@@ -313,7 +321,7 @@ public sealed class Interpreter
         {
             var mv = EvaluateExpression(or.MatchValue!);
             if (!mv.Ok) return Fail(or, mv.Error!);
-            var whereRes = await _session.OpenRowWhereAsync(or.MatchColumn, mv.Value, or.AsHandle, or.Location, or.DetailName).ConfigureAwait(false);
+            var whereRes = await Current.OpenRowWhereAsync(or.MatchColumn, mv.Value, or.AsHandle, or.Location, or.DetailName).ConfigureAwait(false);
             return Wrap(or, whereRes);
         }
 
@@ -321,7 +329,7 @@ public sealed class Interpreter
         if (!v.Ok) return Fail(or, v.Error!);
         if (!TryCoerceInt(v.Value, out var index))
             return Fail(or, new Diagnostic(ErrorKind.ParseInvalidValue, "OPEN-ROW needs an integer index.", or.Location));
-        var res = await _session.OpenRowAsync(index, or.AsHandle, or.Location, or.DetailName).ConfigureAwait(false);
+        var res = await Current.OpenRowAsync(index, or.AsHandle, or.Location, or.DetailName).ConfigureAwait(false);
         return Wrap(or, res);
     }
 
@@ -346,7 +354,7 @@ public sealed class Interpreter
                 return Fail(sr, new Diagnostic(ErrorKind.ParseInvalidValue, "SELECT-ROWS needs an integer index.", sr.Location));
             index = idx;
         }
-        var res = await _session.SelectRowsAsync(sr.All, sr.None, index, sr.MatchColumn, matchValue, sr.DetailName, sr.Location).ConfigureAwait(false);
+        var res = await Current.SelectRowsAsync(sr.All, sr.None, index, sr.MatchColumn, matchValue, sr.DetailName, sr.Location).ConfigureAwait(false);
         return Wrap(sr, res);
     }
 
@@ -356,8 +364,8 @@ public sealed class Interpreter
         if (!v.Ok) return Fail(s, v.Error!);
         ReferenceHint? hint = s.Hint is null ? null : new ReferenceHint(s.Hint.Value, AsString(v.Value));
         var res = s.Scope is null
-            ? await _session.SetAttributeAsync(s.Attribute, v.Value, s.Location, hint).ConfigureAwait(false)
-            : await _session.SetScopedAttributeAsync(s.Scope, s.Attribute, v.Value, hint, s.Location).ConfigureAwait(false);
+            ? await Current.SetAttributeAsync(s.Attribute, v.Value, s.Location, hint).ConfigureAwait(false)
+            : await Current.SetScopedAttributeAsync(s.Scope, s.Attribute, v.Value, hint, s.Location).ConfigureAwait(false);
         return Wrap(s, res);
     }
 
@@ -391,7 +399,7 @@ public sealed class Interpreter
                     a.Location,
                     Hint: "Omit the `= …` clause to invoke without an option, or pass a label string / `ID <index>`."));
         }
-        var res = await _session.ExecuteActionAsync(a.ActionName, parameters, option, a.OptionHint, a.Location, a.DetailName).ConfigureAwait(false);
+        var res = await Current.ExecuteActionAsync(a.ActionName, parameters, option, a.OptionHint, a.Location, a.DetailName).ConfigureAwait(false);
         return a.ExpectError ? WrapExpectingError(a, res) : Wrap(a, res);
     }
 
@@ -404,7 +412,7 @@ public sealed class Interpreter
             if (!v.Ok) return Fail(q, v.Error!);
             text = AsString(v.Value);
         }
-        var res = await _session.SearchAsync(text, q.Location, q.DetailName).ConfigureAwait(false);
+        var res = await Current.SearchAsync(text, q.Location, q.DetailName).ConfigureAwait(false);
         return Wrap(q, res);
     }
 
@@ -431,7 +439,7 @@ public sealed class Interpreter
             args[k] = v.Value;
         }
 
-        var ctx = new ToolContext(_session, _vars, tc.Location, tc.Name);
+        var ctx = new ToolContext(Current, _vars, tc.Location, tc.Name);
         ScriptToolResult result;
         try
         {
@@ -578,7 +586,7 @@ public sealed class Interpreter
     private StatementResult DoExpectClientOperation(ExpectStmt ex)
     {
         var opType = ex.Subject.Name!;
-        var matches = _session.LastOperations
+        var matches = Current.LastOperations
             .Where(o => string.Equals(o.Type, opType, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
@@ -601,7 +609,7 @@ public sealed class Interpreter
         if (ex.Op == ExpectOp.IsNotNull || ex.Value is null)
         {
             if (matches.Count > 0) return Ok(ex);
-            var seen = _session.LastOperations.Select(o => o.Type).Distinct().ToArray();
+            var seen = Current.LastOperations.Select(o => o.Type).Distinct().ToArray();
             return Fail(ex, new Diagnostic(
                 ErrorKind.AssertFailed,
                 $"Expected a '{opType}' client operation but saw {(seen.Length == 0 ? "none" : string.Join(", ", seen))}.",
@@ -669,8 +677,8 @@ public sealed class Interpreter
 
     private OpResult<object?> ResolveExpectSubject(ExpectSubject subj, SourceLocation loc)
     {
-        var po = _session.CurrentPo;
-        var query = _session.CurrentQuery;
+        var po = Current.CurrentPo;
+        var query = Current.CurrentQuery;
 
         // EXPECT Detail "<name>" IS [NOT] AVAILABLE | VISIBLE — flag check against PO.Queries.
         // Handled before the DetailName-as-query-redirect path because IS AVAILABLE specifically
@@ -702,7 +710,7 @@ public sealed class Interpreter
         // identical to the current-query EXPECT TotalItems contract.
         if (subj.DetailName is not null)
         {
-            var detail = _session.ResolveDetail(subj.DetailName, loc);
+            var detail = Current.ResolveDetail(subj.DetailName, loc);
             if (!detail.Ok) return Fail<object?>(detail.Error!);
             query = detail.Value;
         }
@@ -713,7 +721,7 @@ public sealed class Interpreter
                 {
                     if (subj.Scope is not null)
                     {
-                        var scopedAttr = _session.GetScopedAttributeValue(subj.Scope, subj.Name!, loc);
+                        var scopedAttr = Current.GetScopedAttributeValue(subj.Scope, subj.Name!, loc);
                         if (scopedAttr.Ok) return scopedAttr;
                         // `@scope.Prop` may be a PO scalar (FullTypeName, Type, IsNew, …) rather
                         // than an attribute — common for @initial where the script wants to
@@ -722,7 +730,7 @@ public sealed class Interpreter
                         // still surface as-is.
                         if (scopedAttr.Error!.Kind == ErrorKind.ResolveAttribute)
                         {
-                            var scopePo = _session.ResolveScopePo(subj.Scope, loc);
+                            var scopePo = Current.ResolveScopePo(subj.Scope, loc);
                             if (scopePo.Ok)
                             {
                                 var poProp = ReadPoProperty(scopePo.Value!, subj.Name!, loc);
@@ -784,7 +792,7 @@ public sealed class Interpreter
                     PersistentObjectAttribute? attr;
                     if (subj.Scope is not null)
                     {
-                        var scoped = _session.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
+                        var scoped = Current.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
                         if (!scoped.Ok) return Fail<object?>(scoped.Error!);
                         attr = scoped.Value!.Attribute;
                     }
@@ -829,18 +837,18 @@ public sealed class Interpreter
                     return Fail<object?>(new Diagnostic(ErrorKind.StateNoCurrentQuery, "EXPECT Selection.AllSelected needs a current Query.", loc));
                 return OpResult<object?>.Success((object?)query.AllSelected);
             case ExpectSubjectKind.NavStackDepth:
-                return OpResult<object?>.Success((object?)_session.NavStackDepth);
+                return OpResult<object?>.Success((object?)Current.NavStackDepth);
             case ExpectSubjectKind.NavStackTopKind:
-                return OpResult<object?>.Success((object?)_session.NavStackTop?.Kind);
+                return OpResult<object?>.Success((object?)Current.NavStackTop?.Kind);
             case ExpectSubjectKind.NavStackTopName:
-                return OpResult<object?>.Success((object?)_session.NavStackTop?.Name);
+                return OpResult<object?>.Success((object?)Current.NavStackTop?.Name);
             case ExpectSubjectKind.NavStackTopIsDialog:
-                return OpResult<object?>.Success((object?)(_session.NavStackTop?.IsDialog ?? false));
+                return OpResult<object?>.Success((object?)(Current.NavStackTop?.IsDialog ?? false));
             case ExpectSubjectKind.AttributeLabel:
                 {
                     if (subj.Scope is not null)
                     {
-                        var scoped = _session.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
+                        var scoped = Current.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
                         if (!scoped.Ok) return Fail<object?>(scoped.Error!);
                         return OpResult<object?>.Success((object?)scoped.Value!.Attribute.Label);
                     }
@@ -958,9 +966,9 @@ public sealed class Interpreter
                     // shape is to *observe* presence/absence, not error on it. Bypass the
                     // diagnostic by reading Client.Initial / Client.Session straight.
                     if (string.Equals(subj.Scope, "initial", StringComparison.OrdinalIgnoreCase))
-                        return OpResult<object?>.Success((object?)_session.Client.Initial);
+                        return OpResult<object?>.Success((object?)Current.Client.Initial);
                     if (string.Equals(subj.Scope, "session", StringComparison.OrdinalIgnoreCase))
-                        return OpResult<object?>.Success((object?)_session.Client.Session);
+                        return OpResult<object?>.Success((object?)Current.Client.Session);
                     return Fail<object?>(new Diagnostic(ErrorKind.ResolveVariable,
                         $"Unknown variable scope '@{subj.Scope}'.", loc,
                         Hint: "Valid scopes: @session, @initial."));
@@ -987,11 +995,11 @@ public sealed class Interpreter
     {
         if (subj.Scope is not null)
         {
-            var scoped = _session.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
+            var scoped = Current.ResolveScopedAttribute(subj.Scope, subj.Name!, loc);
             if (!scoped.Ok) return OpResult<PersistentObjectAttribute>.Fail(scoped.Error!);
             return OpResult<PersistentObjectAttribute>.Success(scoped.Value!.Attribute);
         }
-        var po = _session.CurrentPo;
+        var po = Current.CurrentPo;
         if (po is null)
             return OpResult<PersistentObjectAttribute>.Fail(new Diagnostic(ErrorKind.StateNoCurrentPo,
                 $"EXPECT Attribute {subj.Name} needs a current PersistentObject.", loc));
@@ -1089,7 +1097,7 @@ public sealed class Interpreter
             case IdentifierExpr i: return OpResult<object?>.Success(i.Name);
             case InterpExpr interp: return EvaluateInterpolation(interp);
             case StringInterpExpr si: return EvaluateStringInterp(si);
-            case VariableAttributeExpr v: return _session.GetScopedAttributeValue(v.Scope, v.AttributeName, v.Location);
+            case VariableAttributeExpr v: return Current.GetScopedAttributeValue(v.Scope, v.AttributeName, v.Location);
         }
         return Fail<object?>(new Diagnostic(ErrorKind.ParseUnexpectedToken, "Unhandled expression.", expr.Location));
     }
@@ -1165,7 +1173,7 @@ public sealed class Interpreter
                     ErrorKind.ResolveVariable,
                     $"`@{scope}` is a PO reference, not a value — use `@{scope}.<attr>`.",
                     interp.Location));
-            return _session.GetScopedAttributeValue(scope, attr, interp.Location);
+            return Current.GetScopedAttributeValue(scope, attr, interp.Location);
         }
         // {{Messages.Saved}} — look up the server-localized client message by key. Surfaces the
         // same strings the UI uses, so assertions can compare against "what the user would read"
@@ -1177,12 +1185,12 @@ public sealed class Interpreter
                 return Fail<object?>(new Diagnostic(ErrorKind.ResolveVariable,
                     "Empty Messages key.", interp.Location,
                     Hint: "Use {{Messages.<key>}} — e.g. {{Messages.Save}}."));
-            if (_session.Client.Messages.TryGetValue(key, out var msg))
+            if (Current.Client.Messages.TryGetValue(key, out var msg))
                 return OpResult<object?>.Success(msg);
             return Fail<object?>(new Diagnostic(ErrorKind.ResolveVariable,
                 $"No client message named '{key}'.",
                 interp.Location,
-                Hint: Suggester.Hint(key, _session.Client.Messages.Keys)));
+                Hint: Suggester.Hint(key, Current.Client.Messages.Keys)));
         }
         // {{env:NAME}} — loud-on-missing environment lookup (a missing var never silently becomes an empty
         // value). Resolves through the injectable EnvLookup, so `--env-file` / hermetic test hosts feed it.
@@ -1405,6 +1413,12 @@ public sealed class Interpreter
     private StatementResult Wrap(Statement stmt, OpResult res) =>
         res.Ok ? Ok(stmt) : Fail(stmt, res.Error!);
 
+    /// <summary>Same polarity as the non-generic <see cref="Wrap(Statement, OpResult)"/>, for the
+    /// <see cref="SessionBook"/> calls that return a payload the interpreter doesn't need (the slot is
+    /// already reflected through <c>Current</c>): pass on success, surface the diagnostic on failure.</summary>
+    private StatementResult Wrap<T>(Statement stmt, OpResult<T> res) =>
+        res.Ok ? Ok(stmt) : Fail(stmt, res.Error!);
+
     /// <summary>Inverts <see cref="Wrap"/>'s polarity for a verb carrying the <c>EXPECTING ERROR</c>
     /// suffix. The verb passes iff the server returned an error notification
     /// (<see cref="ErrorKind.AssertNotificationError"/>) — and because the session leaves that
@@ -1428,15 +1442,15 @@ public sealed class Interpreter
     }
 
     private StatementResult Ok(Statement stmt) =>
-        new(stmt, true, _session.TakeSnapshot(), Array.Empty<Diagnostic>());
+        new(stmt, true, Current.TakeSnapshot(), Array.Empty<Diagnostic>());
 
     private StatementResult Fail(Statement stmt, Diagnostic d) =>
-        new(stmt, false, _session.TakeSnapshot(), new[] { d });
+        new(stmt, false, Current.TakeSnapshot(), new[] { d });
 
     /// <summary>A skipped statement: a non-failing pass that did not execute. <paramref name="d"/>
     /// carries an informational diagnostic explaining the skip (e.g. an unmet REQUIRES).</summary>
     private StatementResult Skip(Statement stmt, Diagnostic? d) =>
-        new(stmt, true, _session.TakeSnapshot(),
+        new(stmt, true, Current.TakeSnapshot(),
             d is null ? Array.Empty<Diagnostic>() : new[] { d },
             Skipped: true);
 }

--- a/Vidyano.Script/Runtime/SessionBook.cs
+++ b/Vidyano.Script/Runtime/SessionBook.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Vidyano.Script.Diagnostics;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Vidyano.Script.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("vidyano")]
+
+namespace Vidyano.Script.Runtime;
+
+/// <summary>
+/// Owns the multi-identity machinery behind the <c>SIGN-IN @name</c> / <c>USE @name</c> /
+/// <c>SIGN-OUT</c> verbs: a name→<see cref="VidyanoSession"/> map, the current pointer, the
+/// transport-mint factory, and disposal. The interpreter never sees the map — it reads
+/// <see cref="Current"/> for the ~43 verb/EXPECT sites and makes exactly three calls
+/// (<see cref="SignInSlotAsync"/>, <see cref="Use"/>, <see cref="SignOut"/>), each returning an
+/// <see cref="OpResult"/> so a name miss is a loud diagnostic, never a throw.
+/// </summary>
+/// <remarks>
+/// Three invariants the names alone don't carry:
+/// <list type="bullet">
+/// <item>The cookie-jar trap: every minted identity MUST get its OWN <c>HttpClient</c> +
+/// <c>CookieContainer</c>. That is why <c>mintFresh</c> is built from the
+/// <c>VidyanoSession(baseUri, acceptAnyServerCertificate)</c> own-jar ctor branch and must never
+/// close over a shared client — sharing a jar silently conflates two identities at runtime with no
+/// compile error.</item>
+/// <item>The <c>""</c> floor: the default (unnamed) slot has map key <c>""</c>, is unaddressable by
+/// <c>USE</c> (the parser requires <c>@name</c>), and is never removed or disposed. It keeps
+/// <see cref="Current"/> non-null for a script's whole life, so <c>SIGN-OUT</c> of the active slot
+/// can always repoint to it.</item>
+/// <item>The disposal-ownership split: the caller-supplied <c>initial</c> transport is owned by the
+/// runner and never disposed here; only sessions the book MINTS are owned and disposed by the book
+/// (on <c>SIGN-OUT</c> of a named slot and in <see cref="Dispose"/>).</item>
+/// </list>
+/// </remarks>
+internal sealed class SessionBook : IDisposable
+{
+    private const string DefaultSlot = "";
+
+    private readonly Dictionary<string, VidyanoSession> _sessions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _minted = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Func<ValueTask<VidyanoSession>> _mintFresh;
+    private string _currentName = DefaultSlot;
+
+    /// <param name="initial">The default-slot (<c>""</c>) session the caller already built. Owned by
+    /// the caller — the book never disposes it.</param>
+    /// <param name="mintFresh">Mints a NEW identity with its OWN <c>HttpClient</c> +
+    /// <c>CookieContainer</c> rooted at the same base URI. Sessions the book mints are owned and
+    /// disposed by the book. Must NOT close over a shared/supplied client (the cookie-jar trap).</param>
+    public SessionBook(VidyanoSession initial, Func<ValueTask<VidyanoSession>> mintFresh)
+    {
+        _sessions[DefaultSlot] = initial;
+        _mintFresh = mintFresh;
+    }
+
+    /// <summary>The active session. Never null after construction — the <c>""</c> floor is present
+    /// until a script explicitly signs it out, and even then the slot stays in the map (disconnected).</summary>
+    public VidyanoSession Current => _sessions[_currentName];
+
+    /// <summary>Selects (and, for a new named slot, mints) the session a following
+    /// <c>SignInAsync</c> authenticates. A <c>null</c>/empty <paramref name="name"/> selects the
+    /// default <c>""</c> slot and mints nothing — the zero-cost single-session path. A named slot is
+    /// minted on first use; a repeat name switches to the EXISTING session and re-authenticates it in
+    /// place (no second jar, no nav-state reset — the collision rule). Returns the selected session.</summary>
+    public async ValueTask<OpResult<VidyanoSession>> SignInSlotAsync(string? name)
+    {
+        var key = name ?? DefaultSlot;
+        if (!_sessions.TryGetValue(key, out var session))
+        {
+            session = await _mintFresh().ConfigureAwait(false);
+            _sessions[key] = session;
+            _minted.Add(key);
+        }
+        _currentName = key;
+        return OpResult<VidyanoSession>.Success(session);
+    }
+
+    /// <summary>Switches the active session to the named slot. Only NAMED slots are addressable — the
+    /// default <c>""</c> floor is unreachable by name (the parser requires <c>@name</c>). An unknown
+    /// name is a non-throwing failure carrying <see cref="ErrorKind.ResolveSession"/> and a
+    /// "did you mean" hint over the known names.</summary>
+    public OpResult<VidyanoSession> Use(string name, SourceLocation loc)
+    {
+        if (!_sessions.TryGetValue(name, out var session))
+            return OpResult<VidyanoSession>.Fail(UnknownSession(name, loc));
+        _currentName = name;
+        return OpResult<VidyanoSession>.Success(session);
+    }
+
+    /// <summary>Signs out a slot (the current one when <paramref name="name"/> is null, else the named
+    /// one). Always performs the faithful <c>viSignOut</c> server action + auth clear via
+    /// <see cref="Vidyano.Client.SignOut"/> (already error-swallowing). A MINTED slot is then disposed
+    /// and removed from the map; the default <c>""</c> floor is left present-but-disconnected (never
+    /// removed) so the next verb fails loudly with the existing not-signed-in guard. When the
+    /// signed-out slot was the active one, <see cref="Current"/> repoints to the <c>""</c> floor.</summary>
+    public async ValueTask<OpResult<bool>> SignOut(string? name, SourceLocation loc)
+    {
+        var key = name ?? _currentName;
+        if (!_sessions.TryGetValue(key, out var session))
+            return OpResult<bool>.Fail(UnknownSession(key, loc));
+
+        await session.Client.SignOut().ConfigureAwait(false);
+
+        // Only a minted slot owns its transport, so only a minted slot is disposed + removed. The ""
+        // floor stays in the map (disconnected) to keep Current non-null.
+        if (_minted.Contains(key))
+        {
+            session.Dispose();
+            _sessions.Remove(key);
+            _minted.Remove(key);
+            if (string.Equals(_currentName, key, StringComparison.OrdinalIgnoreCase))
+                _currentName = DefaultSlot;
+        }
+
+        return OpResult<bool>.Success(true);
+    }
+
+    private Diagnostic UnknownSession(string name, SourceLocation loc) =>
+        new(ErrorKind.ResolveSession,
+            $"No session named '@{name}'.",
+            loc,
+            Hint: Suggester.Hint(name, _sessions.Keys.Where(k => k.Length > 0), "session")
+                  ?? "Open one first with `SIGN-IN @name = user / pass`.");
+
+    public void Dispose()
+    {
+        // Dispose only the sessions the book minted (own-jar transport). The caller-supplied default
+        // slot is owned by the runner and disposed there.
+        foreach (var key in _minted)
+            if (_sessions.TryGetValue(key, out var session))
+                session.Dispose();
+    }
+}

--- a/Vidyano.Script/VidyanoScript.cs
+++ b/Vidyano.Script/VidyanoScript.cs
@@ -70,8 +70,14 @@ public static class VidyanoScript
         try
         {
             var conn = await adapter.StartAsync().ConfigureAwait(false);
-            using var session = new VidyanoSession(conn.BaseUri, conn.HttpClient, opts.AcceptAnyServerCertificate);
-            var interpreter = new Interpreter(session, opts.Variables, opts.Mode, opts.Tools, now: opts.Now, seed: opts.Seed, envLookup: opts.EnvLookup, envPrefix: opts.EnvironmentPrefix);
+            // The default ("") slot reuses the runner-owned transport (conn.HttpClient); named SIGN-INs
+            // mint their OWN cookie jar via the VidyanoSession own-jar ctor branch (the `httpClient: null`
+            // path) so each named identity is isolated. mintFresh must never close over conn.HttpClient.
+            using var sessions = new SessionBook(
+                initial: new VidyanoSession(conn.BaseUri, conn.HttpClient, opts.AcceptAnyServerCertificate),
+                mintFresh: () => new ValueTask<VidyanoSession>(
+                    new VidyanoSession(conn.BaseUri, acceptAnyServerCertificate: opts.AcceptAnyServerCertificate)));
+            var interpreter = new Interpreter(sessions, opts.Variables, opts.Mode, opts.Tools, now: opts.Now, seed: opts.Seed, envLookup: opts.EnvLookup, envPrefix: opts.EnvironmentPrefix);
             return await interpreter.RunAsync(script).ConfigureAwait(false);
         }
         finally

--- a/Vidyano.Script/VidyanoScript.cs
+++ b/Vidyano.Script/VidyanoScript.cs
@@ -73,8 +73,11 @@ public static class VidyanoScript
             // The default ("") slot reuses the runner-owned transport (conn.HttpClient); named SIGN-INs
             // mint their OWN cookie jar via the VidyanoSession own-jar ctor branch (the `httpClient: null`
             // path) so each named identity is isolated. mintFresh must never close over conn.HttpClient.
+            // initial reuses the runner-owned conn.HttpClient, so its Dispose is a no-op today; bind it
+            // to `using` anyway for IDisposable hygiene (SessionBook never disposes the caller's initial).
+            using var initialSession = new VidyanoSession(conn.BaseUri, conn.HttpClient, opts.AcceptAnyServerCertificate);
             using var sessions = new SessionBook(
-                initial: new VidyanoSession(conn.BaseUri, conn.HttpClient, opts.AcceptAnyServerCertificate),
+                initial: initialSession,
                 mintFresh: () => new ValueTask<VidyanoSession>(
                     new VidyanoSession(conn.BaseUri, acceptAnyServerCertificate: opts.AcceptAnyServerCertificate)));
             var interpreter = new Interpreter(sessions, opts.Variables, opts.Mode, opts.Tools, now: opts.Now, seed: opts.Seed, envLookup: opts.EnvLookup, envPrefix: opts.EnvironmentPrefix);


### PR DESCRIPTION
## Summary

Implements the parsed-but-dead `.visc` multi-session verbs in the interpreter: `USE @name`, `SIGN-OUT` / `SIGN-OUT @name`, and named `SIGN-IN @name = user / pass`. The front-end (lexer/parser/AST) already carried the session name; the runtime held a single `VidyanoSession`, so `USE`/`SIGN-OUT` hard-failed "not implemented" and two named `SIGN-IN`s silently collided (the second overwrote the first).

A new internal `SessionBook` owns the name→session map, the current pointer, an own-cookie-jar mint factory, and disposal. The interpreter's `_session` field becomes a `Current` accessor; all 43 read sites are a mechanical rename. **No new public surface, no `IBackendAdapter` change.**

## Semantics (locked during design)

- **Each named session mints its own cookie jar** via the `VidyanoSession` own-jar ctor — *not* the adapter's `StartAsync`, which returns one shared jar — so two named identities never conflate auth (the headline correctness trap).
- The default (`""`) slot is **unaddressable by name** — `USE` only addresses named slots, so name every session you switch between.
- A repeat `SIGN-IN @name` **re-auths the existing slot in place** (no second jar, nav state preserved), uniform with single-session behavior.
- `SIGN-OUT [@name]` performs a **faithful `viSignOut`**, disposes a *minted* session and removes it, and soft-resets the host-owned default slot; the active session falls back to `""`.
- `USE @unknown` is a non-throwing `resolve-session` diagnostic with a "did you mean" suggestion.

## Tests & docs

- New `SessionBookTests` (including the two-named-sessions cookie-jar isolation regression) + a `TestSessionBook` double — **227 tests pass, build green**.
- Docs updated across both package READMEs, `help verbs`/LSP (via `VerbCatalog`), the root `CLAUDE.md` quick-reference table, and a new `samples/sessions.visc`.

## Notes

- The version bump (5.59.0 → 5.60.0) is intentionally **not** in this PR — kept as a separate commit per repo convention.
- 3 pre-existing `VSTHRD200` warnings remain untouched (surgical scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)