### PR TITLE
feat: .visc REPL outcome output + :state, richer Snapshot; drop GOTO/RELOAD

### DIFF
--- a/Vidyano.Script.Tests/VerbCatalogReconciliationTests.cs
+++ b/Vidyano.Script.Tests/VerbCatalogReconciliationTests.cs
@@ -13,14 +13,14 @@ namespace Vidyano.Script.Tests;
 /// </summary>
 public sealed class VerbCatalogReconciliationTests
 {
-    // The authoritative set the parser recognized before the catalog existed (Parser.cs:20-28).
-    // VerbCatalog.Names is internal to Vidyano.Script, so this list stands in as the contract under test.
+    // The set the parser must still recognize. VerbCatalog.Names is internal to Vidyano.Script, so this
+    // list stands in as the contract under test — every entry must resolve in the catalog.
     private static readonly string[] HistoricalKnownVerbs =
     [
         "SIGN-IN", "SIGN-OUT", "USE", "OPEN", "OPEN-ROW", "GO-BACK", "FOLLOW", "OPEN-DETAIL",
-        "EDIT", "CANCEL", "SAVE", "REFRESH", "RELOAD",
+        "EDIT", "CANCEL", "SAVE", "REFRESH",
         "SET", "ACTION", "SEARCH", "SELECT-ROWS",
-        "EXPECT", "GOTO",
+        "EXPECT",
         "TOOL",
         "REQUIRES", "CLEANUP",
     ];

--- a/Vidyano.Script.Tool/ConsoleReporter.cs
+++ b/Vidyano.Script.Tool/ConsoleReporter.cs
@@ -108,7 +108,11 @@ public static class ConsoleReporter
     {
         var detail = sr.DetailName is null ? "" : $"Detail \"{Markup.Escape(sr.DetailName)}\" ";
         var target = sr.None ? "NONE"
-            : sr.All ? (sr.Index is not null || sr.MatchColumn is not null ? "ALL EXCEPT …" : "ALL")
+            : sr.All ? (
+                sr.Index is not null ? $"ALL EXCEPT {DescribeValue(sr.Index)}"
+                : sr.MatchColumn is not null ? $"ALL EXCEPT WHERE {Markup.Escape(sr.MatchColumn)} = …"
+                : "ALL")
+            : sr.Index is not null ? DescribeValue(sr.Index)
             : sr.MatchColumn is not null ? $"WHERE {Markup.Escape(sr.MatchColumn)} = …"
             : "…";
         return detail + target;

--- a/Vidyano.Script.Tool/ConsoleReporter.cs
+++ b/Vidyano.Script.Tool/ConsoleReporter.cs
@@ -98,9 +98,21 @@ public static class ConsoleReporter
             RequiresToolStmt rt        => $"REQUIRES TOOL {Markup.Escape(rt.ToolName)}",
             CleanupMarker              => "CLEANUP",
             UseSessionStmt u           => $"USE @{u.SessionName}",
-            SignOutStmt                => "SIGN-OUT",
+            SignOutStmt so             => so.SessionName is null ? "SIGN-OUT" : $"SIGN-OUT @{so.SessionName}",
+            GoBackStmt                 => "GO-BACK",
+            SelectRowsStmt sr          => $"SELECT-ROWS {DescribeSelectTarget(sr)}",
             _                          => stmt.GetType().Name,
         };
+
+    private static string DescribeSelectTarget(SelectRowsStmt sr)
+    {
+        var detail = sr.DetailName is null ? "" : $"Detail \"{Markup.Escape(sr.DetailName)}\" ";
+        var target = sr.None ? "NONE"
+            : sr.All ? (sr.Index is not null || sr.MatchColumn is not null ? "ALL EXCEPT …" : "ALL")
+            : sr.MatchColumn is not null ? $"WHERE {Markup.Escape(sr.MatchColumn)} = …"
+            : "…";
+        return detail + target;
+    }
 
     private static string DescribeSubject(ExpectSubject s) =>
         s.Kind switch
@@ -145,4 +157,260 @@ public static class ConsoleReporter
             t.AddRow(Markup.Escape(a.Name), Markup.Escape(a.DisplayValue ?? a.Value ?? ""), a.IsReadOnly ? "✓" : "", a.IsRequired ? "✓" : "", a.IsVisible ? "" : "hidden");
         AnsiConsole.Write(t);
     }
+
+    // --- interactive REPL rendering -----------------------------------------------------------
+
+    /// <summary>Renders one just-executed statement for the interactive REPL. Unlike the batch
+    /// <see cref="Write"/> path, this distinguishes pass / skip / fail and — on a pass — shows the
+    /// resulting session state (see <see cref="DescribeOutcome"/>) rather than echoing the typed verb,
+    /// so the prompt reflects where you now are. A skipped (unmet <c>REQUIRES</c>) statement is shown
+    /// as <c>skip</c>, not a misleading green <c>ok</c>; a failure prints its diagnostics as before.</summary>
+    public static void WriteReplLine(StatementResult s)
+    {
+        if (s.Skipped)
+            AnsiConsole.MarkupLine($"[yellow]skip[/] {DescribeOutcome(s)}");
+        else if (s.Ok)
+            AnsiConsole.MarkupLine($"[green]ok[/]   {DescribeOutcome(s)}");
+        else
+            foreach (var d in s.Diagnostics) WriteDiagnostic(d);
+    }
+
+    /// <summary>
+    /// A one-line, outcome-oriented summary of a just-executed statement: what changed and where you
+    /// now are, read from the post-statement <see cref="StatementResult.Snapshot"/>. Distinct from
+    /// <see cref="Describe"/> (a static echo of the parsed verb, used by batch <c>run</c> output): an
+    /// <c>OPEN Query Modules</c> renders as <c>Query "Modules" · 52 items</c>, and an EXPECT/REQUIRES
+    /// shows the assertion that held — not a bare <c>ok</c>. Returns Spectre markup.
+    /// </summary>
+    public static string DescribeOutcome(StatementResult r)
+    {
+        var snap = r.Snapshot;
+        switch (r.Statement)
+        {
+            case SignInStmt si:
+                return $"signed in as {Markup.Escape(snap?.Session?.User ?? "?")}"
+                     + (si.SessionName is null ? "" : $" [grey](@{Markup.Escape(si.SessionName)})[/]");
+            case SignOutStmt so:
+                return so.SessionName is null ? "signed out" : $"signed out [grey]@{Markup.Escape(so.SessionName)}[/]";
+            case UseSessionStmt u:
+                return $"using [yellow]@{Markup.Escape(u.SessionName)}[/]  →  {Frame(snap)}";
+            case OpenQueryStmt or OpenMenuItemStmt:
+                return snap?.Query is { } q ? QueryLine(q) : "opened query";
+            case OpenPersistentObjectStmt or OpenRowStmt:
+                return snap?.Po is { } po ? $"opened {PoLine(po)}" : "opened object";
+            case GoBackStmt:
+                return $"[grey]←[/] back to {Frame(snap)}";
+            case EditStmt:
+                return snap?.Po is { } poe ? $"editing {PoLine(poe)}" : "editing";
+            case CancelStmt:
+                return "cancelled edit";
+            case SaveStmt { ExpectError: true }:
+                return $"error as expected{Notif(snap)}";
+            case SaveStmt:
+                return $"saved{Notif(snap)}";
+            case RefreshStmt:
+                return snap?.Po is { } por ? $"refreshed {PoLine(por)}" : "refreshed";
+            case SetStmt set:
+                return SetLine(set, snap);
+            case ActionStmt { ExpectError: true }:
+                return $"error as expected{Notif(snap)}";
+            case ActionStmt a:
+                return $"ran [yellow]{Markup.Escape(a.ActionName)}[/]{Notif(snap)}";
+            case SearchStmt sq:
+                return sq.DetailName is not null
+                    ? $"detail [bold]\"{Markup.Escape(sq.DetailName)}\"[/] loaded"
+                    : snap?.Query is { } qq ? QueryLine(qq) : "searched";
+            case SelectRowsStmt { DetailName: { } detailName }:
+                // The selection lands on the detail query, which the snapshot doesn't surface — so
+                // report the target rather than the (parent) current-query selection.
+                return $"selection set on detail [bold]\"{Markup.Escape(detailName)}\"[/]";
+            case SelectRowsStmt:
+                return $"selection: {(snap?.Query is { } qs ? SelectionText(qs) : "none")}";
+            case ExpectStmt e:
+                return $"{ExpectAssertion(e)}  [green]✓[/]";
+            case RequiresStmt rq:
+                return $"requires {ExpectAssertion(new ExpectStmt(rq.Subject, rq.Op, rq.Value, rq.Location))} — "
+                     + (r.Skipped ? "[yellow]unmet[/]" : "[green]met[/]");
+            case RequiresToolStmt rt:
+                return $"requires tool [yellow]{Markup.Escape(rt.ToolName)}[/] — "
+                     + (r.Skipped ? "[yellow]missing[/]" : "[green]present[/]");
+            case ToolCallStmt t:
+                return $"tool [yellow]{Markup.Escape(t.Name)}[/] ran"
+                     + (t.ResultVariable is null ? "" : $"  →  [grey]@{Markup.Escape(t.ResultVariable)}[/]");
+            case VariableAssignment v:
+                return $"[grey]@{Markup.Escape(v.Name)} set[/]";
+            case ModeDirective md:
+                return $"[grey]@mode = {md.Mode.ToString().ToLowerInvariant()}[/]";
+            case CleanupMarker:
+                return "[grey]cleanup[/]";
+            default:
+                return Describe(r.Statement);
+        }
+    }
+
+    private static string PoLine(PoSnapshot po)
+    {
+        var id = string.IsNullOrEmpty(po.ObjectId) ? "new" : po.ObjectId!;
+        var s = $"[bold]{Markup.Escape(po.Type)}[/] · {Markup.Escape(id)}";
+        if (po.IsInEdit) s += " [grey][[edit]][/]";
+        if (po.IsDirty) s += " [yellow][[dirty]][/]";
+        return s;
+    }
+
+    private static string QueryLine(QuerySnapshot q)
+    {
+        var s = $"Query [bold]\"{Markup.Escape(q.Name)}\"[/] · {q.TotalItems} {Plural(q.TotalItems, "item")}";
+        if (!string.IsNullOrEmpty(q.TextSearch)) s += $"  [grey](search: \"{Markup.Escape(q.TextSearch!)}\")[/]";
+        return s;
+    }
+
+    private static string Frame(Snapshot? snap) =>
+        snap?.Po is { } po ? PoLine(po)
+        : snap?.Query is { } q ? QueryLine(q)
+        : "[grey](empty)[/]";
+
+    private static string Notif(Snapshot? snap)
+    {
+        var n = snap?.Po?.Notification;
+        return string.IsNullOrEmpty(n) ? "" : $"  [grey]·[/] \"{Markup.Escape(n!)}\"";
+    }
+
+    private static string SetLine(SetStmt set, Snapshot? snap)
+    {
+        // A scoped SET (@session.X) writes the session PO, which the snapshot carries separately —
+        // read from there so the outcome shows the value rather than the "value-unavailable" sentinel.
+        var po = string.Equals(set.Scope, "session", StringComparison.OrdinalIgnoreCase) ? snap?.SessionPo : snap?.Po;
+        var attr = po?.Attributes.FirstOrDefault(a => string.Equals(a.Name, set.Attribute, StringComparison.OrdinalIgnoreCase));
+        var val = attr is null ? "…" : attr.DisplayValue ?? attr.Value ?? "null";
+        var dirty = po?.IsDirty == true ? "  [yellow](dirty)[/]" : "";
+        return $"{Markup.Escape(set.Attribute)} = {Markup.Escape(val)}{dirty}";
+    }
+
+    private static string SelectionText(QuerySnapshot q)
+    {
+        if (q.AllSelected) return q.SelectedCount > 0 ? $"ALL except {q.SelectedCount}" : "ALL";
+        return q.SelectedCount == 0 ? "none" : $"{q.SelectedCount} {Plural(q.SelectedCount, "row")}";
+    }
+
+    private static string ExpectAssertion(ExpectStmt e)
+    {
+        var detail = e.Subject.DetailName is null ? "" : $"Detail \"{Markup.Escape(e.Subject.DetailName)}\" ";
+        var subj = detail + DescribeSubject(e.Subject);
+        return e.Op switch
+        {
+            ExpectOp.IsNull    => $"{subj} IS NULL",
+            ExpectOp.IsNotNull => $"{subj} IS NOT NULL",
+            ExpectOp.Is        => $"{subj} IS {FlagOrValue(e)}",
+            ExpectOp.IsNot     => $"{subj} IS NOT {FlagOrValue(e)}",
+            _                  => $"{subj} {OpSymbol(e.Op)} {DescribeValue(e.Value)}",
+        };
+    }
+
+    private static string FlagOrValue(ExpectStmt e) =>
+        e.Subject.Flag != AttributeFlagKind.None
+            ? e.Subject.Flag.ToString().ToUpperInvariant()
+            : DescribeValue(e.Value);
+
+    private static string OpSymbol(ExpectOp op) => op switch
+    {
+        ExpectOp.Eq => "=", ExpectOp.NotEq => "!=", ExpectOp.Lt => "<", ExpectOp.LtEq => "<=",
+        ExpectOp.Gt => ">", ExpectOp.GtEq => ">=", ExpectOp.Contains => "CONTAINS",
+        ExpectOp.NotContains => "NOT CONTAINS", ExpectOp.Matches => "MATCHES",
+        _ => op.ToString(),
+    };
+
+    private static string DescribeValue(Expression? e) => e switch
+    {
+        null => "",
+        LiteralExpr { Value: null } => "null",
+        LiteralExpr { Value: string sv } => $"\"{Markup.Escape(sv)}\"",
+        LiteralExpr lit => Markup.Escape(lit.Value?.ToString() ?? ""),
+        IdentifierExpr id => Markup.Escape(id.Name),
+        InterpExpr ie => "{{" + Markup.Escape(ie.Inner) + "}}",
+        StringInterpExpr si => "\"" + Markup.Escape(string.Concat(si.Parts.Select(
+            p => p is InterpExpr hole ? "{{" + hole.Inner + "}}" : p?.ToString() ?? ""))) + "\"",
+        VariableAttributeExpr va => Markup.Escape($"@{va.Scope}.{va.AttributeName}"),
+        _ => "…",
+    };
+
+    private static string Plural(int n, string word) => n == 1 ? word : word + "s";
+
+    // --- :state — focused current-frame view --------------------------------------------------
+
+    /// <summary>Renders a focused, human-readable view of the current frame for the REPL's
+    /// <c>:state</c>: the active sign-in, the navigation breadcrumb, and either the current PO
+    /// (attributes, actions, detail-query names, notification) or the current Query (totals, search,
+    /// actions, a head of rows). The deliberately small counterpart to <c>:snapshot</c>'s raw JSON.</summary>
+    public static void RenderState(Snapshot snap)
+    {
+        if (snap.Session is { } s)
+            AnsiConsole.MarkupLine($"[grey]session:[/] {Markup.Escape(s.User ?? "?")} [grey]@[/] {Markup.Escape(s.Uri ?? "?")}");
+        else
+            AnsiConsole.MarkupLine("[grey]session:[/] [yellow]not signed in[/]");
+
+        if (snap.NavStack is { Count: > 0 } nav)
+        {
+            var crumbs = nav.Select(f => f.IsDialog ? $"[grey][[[/]{Markup.Escape(f.Name)}[grey]]][/]" : Markup.Escape(f.Name));
+            AnsiConsole.MarkupLine($"[grey]nav:[/] {string.Join(" [grey]›[/] ", crumbs)}");
+        }
+        else
+            AnsiConsole.MarkupLine("[grey]nav:[/] [grey](empty)[/]");
+
+        if (snap.Po is { } po)
+            RenderPoState(po);
+        else if (snap.Query is { } q)
+            RenderQueryState(q);
+        else
+            AnsiConsole.MarkupLine("[grey](no current frame)[/]");
+    }
+
+    private static void RenderPoState(PoSnapshot po)
+    {
+        var id = string.IsNullOrEmpty(po.ObjectId) ? "<new>" : po.ObjectId!;
+        var title = $"[bold]{Markup.Escape(po.Type)}[/] / {Markup.Escape(id)}";
+        if (po.IsInEdit) title += " [grey][[edit]][/]";
+        if (po.IsDirty) title += " [yellow][[dirty]][/]";
+        RenderPoTable(po, title);
+
+        if (!string.IsNullOrEmpty(po.Notification))
+            AnsiConsole.MarkupLine($"  [red]![/] [grey]{Markup.Escape(po.NotificationType ?? "")}:[/] {Markup.Escape(po.Notification!)}");
+
+        var actions = po.Actions.Where(a => a.IsVisible).ToList();
+        if (actions.Count > 0)
+            AnsiConsole.MarkupLine($"  [grey]actions:[/] {string.Join(", ", actions.Select(ActionChip))}");
+        if (po.DetailQueries is { Count: > 0 } details)
+            AnsiConsole.MarkupLine($"  [grey]details:[/] {string.Join(", ", details.Select(d => Markup.Escape(d)))}");
+    }
+
+    private static void RenderQueryState(QuerySnapshot q)
+    {
+        var head = $"[bold]Query \"{Markup.Escape(q.Name)}\"[/] · {q.TotalItems} {Plural(q.TotalItems, "item")}, {q.Count} loaded";
+        if (!string.IsNullOrEmpty(q.TextSearch)) head += $"  [grey](search: \"{Markup.Escape(q.TextSearch!)}\")[/]";
+        if (q.AllSelected || q.SelectedCount > 0) head += $"  [grey](selection: {SelectionText(q)})[/]";
+        AnsiConsole.MarkupLine(head);
+
+        if (q.Actions is { Count: > 0 } qActions)
+        {
+            var vis = qActions.Where(a => a.IsVisible).ToList();
+            if (vis.Count > 0)
+                AnsiConsole.MarkupLine($"  [grey]actions:[/] {string.Join(", ", vis.Select(ActionChip))}");
+        }
+
+        if (q.Rows.Count > 0)
+        {
+            // Cap the column count so a wide query doesn't overflow the terminal; the full shape is in :snapshot.
+            const int maxCols = 6;
+            var cols = q.Rows[0].Keys.Take(maxCols).ToList();
+            var t = new Table().Border(TableBorder.Rounded);
+            foreach (var c in cols) t.AddColumn(Markup.Escape(c));
+            foreach (var row in q.Rows)
+                t.AddRow(cols.Select(c => Markup.Escape(row.TryGetValue(c, out var v) ? v ?? "" : "")).ToArray());
+            AnsiConsole.Write(t);
+            var extra = q.Rows[0].Count - cols.Count;
+            if (extra > 0) AnsiConsole.MarkupLine($"  [grey](+{extra} more column(s) — see :snapshot)[/]");
+        }
+    }
+
+    private static string ActionChip(ActionSnapshot a) =>
+        a.CanExecute ? $"{Markup.Escape(a.Name)} [green]✓[/]" : $"[grey]{Markup.Escape(a.Name)} ✗[/]";
 }

--- a/Vidyano.Script.Tool/ReplCommand.cs
+++ b/Vidyano.Script.Tool/ReplCommand.cs
@@ -96,12 +96,7 @@ public static class ReplCommand
             var result = await interpreter.RunAsync(script).ConfigureAwait(false);
             foreach (var step in result.Steps)
                 foreach (var s in step.Statements)
-                {
-                    if (s.Ok)
-                        AnsiConsole.MarkupLine($"[green]ok[/] {ConsoleReporter.Describe(s.Statement)}");
-                    else
-                        foreach (var d in s.Diagnostics) ConsoleReporter.WriteDiagnostic(d);
-                }
+                    ConsoleReporter.WriteReplLine(s);
 
             // Only record lines that parsed; failed-at-runtime lines stay in history so :save replays
             // the same scenario (intentional — captures user intent, not just successes).
@@ -121,7 +116,8 @@ public static class ReplCommand
                 AnsiConsole.MarkupLine("  [yellow]:save <path>[/]    Write the session history as a .visc file.");
                 AnsiConsole.MarkupLine("  [yellow]:load <path>[/]    Run a .visc file in this session.");
                 AnsiConsole.MarkupLine("  [yellow]:vars[/]           List current script variables.");
-                AnsiConsole.MarkupLine("  [yellow]:snapshot[/]       Print the current session snapshot.");
+                AnsiConsole.MarkupLine("  [yellow]:state[/]          Focused view of the current frame (nav, PO/query, actions, details).");
+                AnsiConsole.MarkupLine("  [yellow]:snapshot[/]       Raw JSON of the full session snapshot.");
                 AnsiConsole.MarkupLine("  [yellow]:verbs[/]          List every .visc verb.");
                 AnsiConsole.MarkupLine("  [yellow]:quit[/]           Exit.");
                 return Task.FromResult(true);
@@ -131,6 +127,9 @@ public static class ReplCommand
             case ":vars":
                 foreach (var v in interpreter.Variables.OrderBy(kv => kv.Key))
                     AnsiConsole.MarkupLine($"  @{Markup.Escape(v.Key)} = {Markup.Escape(v.Value?.ToString() ?? "null")}");
+                return Task.FromResult(true);
+            case ":state":
+                ConsoleReporter.RenderState(sessions.Current.TakeSnapshot());
                 return Task.FromResult(true);
             case ":snapshot":
                 {

--- a/Vidyano.Script/Diagnostics/VerbCatalog.cs
+++ b/Vidyano.Script/Diagnostics/VerbCatalog.cs
@@ -24,7 +24,7 @@ public sealed record VerbInfo(
 /// </summary>
 /// <remarks>
 /// Historically there were two diverging lists: <c>Parser.KnownVerbs</c> (which carried
-/// <c>FOLLOW</c>/<c>OPEN-DETAIL</c>/<c>RELOAD</c>/<c>GOTO</c>/<c>REFRESH</c>) and the Tool's
+/// <c>FOLLOW</c>/<c>OPEN-DETAIL</c>/<c>REFRESH</c>) and the Tool's
 /// syntax-form-keyed help table (which did not). This catalog reconciles them: it is keyed by bare
 /// verb name and MUST contain every verb the parser recognizes. The catalog-reconciliation guard test
 /// asserts that <c>Parser.KnownVerbs ⊆ VerbCatalog.Names</c>.
@@ -135,13 +135,6 @@ public static class VerbCatalog
             ["REFRESH"],
             "edit", []),
 
-        new("RELOAD",
-            "RELOAD",
-            "Reload the current frame from the server.",
-            null,
-            ["RELOAD"],
-            "edit", []),
-
         new("SET",
             "SET <attr> = <value>\nSET <attr> = LOOKUP \"<display>\"\nSET <attr> = ID \"<key>\"\nSET <attr> = null",
             "Change an attribute value.",
@@ -185,13 +178,6 @@ public static class VerbCatalog
             + "(1s ReDoS guard). `Detail \"<name>\"` redirects query-family subjects.",
             ["EXPECT Status = \"Approved\"", "EXPECT TotalItems >= 1", "EXPECT Code MATCHES \"^[A-Z]{2}\\d+$\""],
             "assert", []),
-
-        new("GOTO",
-            "GOTO <step>",
-            "Jump to a labeled step.",
-            null,
-            ["GOTO cleanup"],
-            "control", []),
 
         new("TOOL",
             "TOOL <name> [k=v, …] [-> @var]",

--- a/Vidyano.Script/Runtime/Snapshot.cs
+++ b/Vidyano.Script/Runtime/Snapshot.cs
@@ -11,10 +11,16 @@ public sealed record Snapshot(
     PoSnapshot? Po,
     QuerySnapshot? Query,
     IReadOnlyDictionary<string, string>? Handles,
-    PoSnapshot? SessionPo = null);
+    PoSnapshot? SessionPo = null,
+    IReadOnlyList<NavFrameSnapshot>? NavStack = null);
 
 /// <summary>Identifying information about the active sign-in.</summary>
 public sealed record SessionSnapshot(string? User, string? Uri);
+
+/// <summary>One frame of the navigation stack, oldest first. <see cref="Name"/> is the Query name or
+/// PO type; <see cref="Kind"/> is "Query" or "PersistentObject". Mirrors what
+/// <c>EXPECT NavStack.Top.*</c> reads, so the whole stack is visible to agents, not just the top.</summary>
+public sealed record NavFrameSnapshot(string Kind, string Name, bool IsDialog);
 
 /// <summary>Compact view of the top-of-stack PersistentObject.</summary>
 public sealed record PoSnapshot(
@@ -26,7 +32,8 @@ public sealed record PoSnapshot(
     string? Notification,
     string? NotificationType,
     IReadOnlyList<AttributeSnapshot> Attributes,
-    IReadOnlyList<ActionSnapshot> Actions);
+    IReadOnlyList<ActionSnapshot> Actions,
+    IReadOnlyList<string>? DetailQueries = null);
 
 /// <summary>Compact view of one attribute, only the fields the UI/script can reason about.</summary>
 public sealed record AttributeSnapshot(
@@ -43,10 +50,16 @@ public sealed record AttributeSnapshot(
 /// <summary>Compact view of one action, only the fields the UI/script can reason about.</summary>
 public sealed record ActionSnapshot(string Name, bool CanExecute, bool IsVisible);
 
-/// <summary>Compact view of the active query, including a small head of rows.</summary>
+/// <summary>Compact view of the active query, including a small head of rows. <see cref="SelectedCount"/>
+/// is the literal selected-row count (<c>Query.SelectedItems.Count</c>); <see cref="AllSelected"/> is the
+/// server-side select-all flag — when set, <see cref="SelectedCount"/> reports only the exclusion set, not
+/// the full match, mirroring <c>EXPECT Selection.*</c>.</summary>
 public sealed record QuerySnapshot(
     string Name,
     string? TextSearch,
     int TotalItems,
     int Count,
-    IReadOnlyList<IReadOnlyDictionary<string, string?>> Rows);
+    IReadOnlyList<IReadOnlyDictionary<string, string?>> Rows,
+    IReadOnlyList<ActionSnapshot>? Actions = null,
+    int SelectedCount = 0,
+    bool AllSelected = false);

--- a/Vidyano.Script/Runtime/VidyanoSession.cs
+++ b/Vidyano.Script/Runtime/VidyanoSession.cs
@@ -1356,12 +1356,18 @@ public sealed class VidyanoSession : IDisposable
             Rows: CurrentQuery.Take(10).Where(r => r != null)
                 .Select(r => (IReadOnlyDictionary<string, string?>)CurrentQuery.Columns.ToDictionary(
                     c => c.Name,
-                    c => Vidyano.Client.ToServiceString(r[c.Name]) as string)).ToList());
+                    c => Vidyano.Client.ToServiceString(r[c.Name]) as string)).ToList(),
+            Actions: CurrentQuery.Actions.Select(a => new ActionSnapshot(a.Name, a.CanExecute, a.IsVisible)).ToList(),
+            SelectedCount: CurrentQuery.SelectedItems.Count,
+            AllSelected: CurrentQuery.AllSelected);
 
         IReadOnlyDictionary<string, string>? handles = _handles.Count == 0 ? null
             : _handles.ToDictionary(kv => kv.Key, kv => DescribeHandle(kv.Value));
 
-        return new Snapshot(session, po, query, handles, sessionPo);
+        var navStack = _navStack.Count == 0 ? null
+            : _navStack.Select(e => new NavFrameSnapshot(e.Kind, e.Name, e.IsDialog)).ToList();
+
+        return new Snapshot(session, po, query, handles, sessionPo, navStack);
     }
 
     private static PoSnapshot BuildPoSnapshot(PersistentObject po) => new(
@@ -1376,7 +1382,8 @@ public sealed class VidyanoSession : IDisposable
             a.Name, a.Type, a.ValueDirect, SafeDisplay(a),
             a.IsVisible, a.IsReadOnly, a.IsRequired, a.IsValueChanged, a.ValidationError)).ToList(),
         Actions: po.Actions.Concat(po.PinnedActions)
-            .Select(a => new ActionSnapshot(a.Name, a.CanExecute, a.IsVisible)).ToList());
+            .Select(a => new ActionSnapshot(a.Name, a.CanExecute, a.IsVisible)).ToList(),
+        DetailQueries: po.Queries.Keys.ToList());
 
     private static string? SafeDisplay(PersistentObjectAttribute attr)
     {


### PR DESCRIPTION
Small pre-release tweaks to the `.visc` interactive experience, from REPL feedback that the output was hard to read.

## What changed

**REPL result line (`vidyano repl`)** — each executed line now prints an *outcome* derived from the post-statement snapshot (what changed / where you are) instead of a static verb echo:
- `OPEN Query Modules` → `Query "Modules" · 52 items`
- `SET Label = "Hi"` → `Label = "Hi"  (dirty)`
- `EXPECT TotalItems = 52` → `TotalItems = 52  ✓`
- Fixes the trailing `…` placeholder and the raw class-name leak (`SELECT-ROWS`/`GO-BACK` used to print `SelectRowsStmt`).
- An **unmet `REQUIRES`** now renders `skip … unmet` instead of a misleading green `ok` (it's `Ok=true` + `Skipped=true`; `WriteReplLine` tests `Skipped` before `Ok`).

**New `:state` command** — a focused, human-readable view of the current frame (session, nav breadcrumb, current PO/Query with attributes, actions, detail-query names, notification). `:snapshot` stays the raw JSON dump.

**Richer `Snapshot` contract** — added NavStack frames, PO detail-query names, query actions, and query selection (`SelectedCount` + `AllSelected`). Additive (defaults), so it also enriches `--json` NDJSON.

**Verb catalog cleanup** — removed `GOTO` and `RELOAD` (never implemented). `REFRESH` (implemented) and `FOLLOW`/`OPEN-DETAIL` (planned) stay listed. Typing `GOTO`/`RELOAD` now yields a clean *"Unknown verb"* + suggestion.

## Quality gates

Ran the implement→review→verify pipeline on the diff:
- **Build:** clean across all targets. **Tests:** 227/227 pass (`Vidyano.Script.Tests`).
- **Code review:** no blocking issues; markup escaping, null-safety, and the `Skipped`-before-`Ok` ordering all confirmed.
- **Spec conformance:** all items OK.

## Notes

- No version bump in this PR (held per request — 5.60.0 suggested for the release commit).
- No automated tests for the Tool-side console rendering: `Vidyano.Script.Tests` deliberately doesn't reference `Vidyano.Script.Tool`. The verb-catalog change is covered by the (passing) reconciliation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)