### PR TITLE
feat: .visc EXPECT Action … IS [NOT] AVAILABLE/VISIBLE tolerates an absent action

### DIFF
--- a/Vidyano.Script.Tests/ExpectActionAbsentLintTests.cs
+++ b/Vidyano.Script.Tests/ExpectActionAbsentLintTests.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using Vidyano.Script;
+using Vidyano.Script.Parsing;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Grammar coverage for <c>EXPECT Action X IS [NOT] AVAILABLE | VISIBLE</c> — the forms that let a
+/// script assert an action was filtered out of a PersistentObject (e.g. removed server-side via
+/// <c>DisableActions</c>). These assert the parse shape only: an absent action is resolved against
+/// <c>Current.CurrentPo</c>, which is populated from server JSON, so the runtime behavior — an absent
+/// action answering <c>false</c> for an explicit flag (passing <c>IS NOT AVAILABLE</c>, failing the
+/// assertion on <c>IS AVAILABLE</c>) while a flagless form still errors with <c>ResolveAction</c> to
+/// preserve typo detection — needs a live server and is verified downstream. Lint-only, mirroring
+/// <see cref="RetryActionLintTests"/>.
+/// </summary>
+public sealed class ExpectActionAbsentLintTests
+{
+    private static void AssertClean(string body)
+    {
+        var diags = VidyanoScript.Lint(body);
+        Assert.True(diags.Count == 0,
+            $"Expected no diagnostics, got: {string.Join("; ", diags.Select(d => $"{d.Kind}: {d.Message}"))}");
+    }
+
+    private static ExpectStmt SingleExpect(string body)
+    {
+        var lexer = new Lexer(body, "<test>");
+        var parser = new Parser(lexer.Tokenize(), lexer.Diagnostics);
+        var ast = parser.Parse();
+        Assert.True(parser.Diagnostics.Count == 0,
+            $"Parse errors: {string.Join("; ", parser.Diagnostics.Select(d => d.Message))}");
+        var stmts = ast.Steps.SelectMany(s => s.Statements).ToList();
+        Assert.Single(stmts);
+        return Assert.IsType<ExpectStmt>(stmts[0]);
+    }
+
+    // The (Flag, Op) shape is the contract the runtime branch depends on: Flag picks the property
+    // (CanExecute / IsVisible), Op carries the IS / IS NOT negation that turns an absent action's
+    // `false` into a pass or an assertion failure.
+    [Theory]
+    [InlineData("EXPECT Action Delete IS AVAILABLE", AttributeFlagKind.Available, ExpectOp.Is)]
+    [InlineData("EXPECT Action Delete IS NOT AVAILABLE", AttributeFlagKind.Available, ExpectOp.IsNot)]
+    [InlineData("EXPECT Action Delete IS VISIBLE", AttributeFlagKind.Visible, ExpectOp.Is)]
+    [InlineData("EXPECT Action Delete IS NOT VISIBLE", AttributeFlagKind.Visible, ExpectOp.IsNot)]
+    public void ActionFlagForms_ParseToExpectedShape(string body, AttributeFlagKind flag, ExpectOp op)
+    {
+        var stmt = SingleExpect(body);
+        Assert.Equal(ExpectSubjectKind.Action, stmt.Subject.Kind);
+        Assert.Equal("Delete", stmt.Subject.Name);
+        Assert.Equal(flag, stmt.Subject.Flag);
+        Assert.Equal(op, stmt.Op);
+    }
+
+    [Theory]
+    [InlineData("EXPECT Action Delete IS AVAILABLE")]
+    [InlineData("EXPECT Action Delete IS NOT AVAILABLE")]
+    [InlineData("EXPECT Action Delete IS VISIBLE")]
+    [InlineData("EXPECT Action Delete IS NOT VISIBLE")]
+    public void ActionFlagForms_LintClean(string body)
+    {
+        AssertClean(body);
+    }
+}

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -820,9 +820,19 @@ public sealed class Interpreter
                         .Concat(query?.Actions ?? Array.Empty<Vidyano.ViewModel.Actions.QueryAction>())
                         .Select(a => a.Name);
                     if (action is null)
-                        return Fail<object?>(new Diagnostic(ErrorKind.ResolveAction,
-                            $"Action '{subj.Name}' does not exist here.", loc,
-                            Hint: Suggester.Hint(subj.Name!, candidates)));
+                    {
+                        // An absent action (e.g. removed via DisableActions) is neither visible nor
+                        // executable — answer false for an explicit flag so a script can assert it was
+                        // filtered out (EXPECT Action X IS NOT AVAILABLE). A bare `EXPECT Action X`
+                        // (no flag) still errors, preserving typo detection over candidate names.
+                        return subj.Flag switch
+                        {
+                            AttributeFlagKind.Visible or AttributeFlagKind.Available => OpResult<object?>.Success((object?)false),
+                            _ => Fail<object?>(new Diagnostic(ErrorKind.ResolveAction,
+                                    $"Action '{subj.Name}' does not exist here.", loc,
+                                    Hint: Suggester.Hint(subj.Name!, candidates))),
+                        };
+                    }
                     // IS VISIBLE → IsVisible; IS AVAILABLE → CanExecute. None (no flag yet) defaults
                     // to CanExecute — preserves the bare `EXPECT Action X` historical sense.
                     return subj.Flag switch


### PR DESCRIPTION
## What

`EXPECT Action X IS [NOT] AVAILABLE` and `IS [NOT] VISIBLE` now tolerate an **absent** action — one filtered out of `PO.Actions` (e.g. removed server-side via `PersistentObject.DisableActions`). An absent action answers `false` for an explicit flag, so a script can assert it was filtered out.

## Why

When a host removes an action it is gone from `PO.Actions` entirely (not present-with-`CanExecute=false`). The interpreter previously resolved the action *before* evaluating the flag, so `EXPECT Action X IS NOT AVAILABLE` errored with `ResolveAction` — there was no way to express "this action should be absent here," a common, legitimate assertion.

## Behavior

| Form | Absent action |
|---|---|
| `EXPECT Action X IS NOT AVAILABLE` / `IS NOT VISIBLE` | **passes** |
| `EXPECT Action X IS AVAILABLE` / `IS VISIBLE` | **fails the assertion** — a clean `AssertFailed`, not a resolution error |
| flagless (`Flag None`, reached via a comparison form) | **still errors** `ResolveAction` + suggester hint (typo detection preserved) |

## Scope

- Touches only the `case ExpectSubjectKind.Action:` `action is null` branch in `Interpreter.cs`.
- New `ExpectActionAbsentLintTests` pins the grammar→runtime `(Flag, Op)` contract for the four flag forms. The test project is server-free and cannot construct a `PersistentObject`, so runtime dispatch is verified downstream against a live server — matching the `RetryActionLintTests` / `ExpectingErrorLintTests` precedent.
- No package version bump (handled separately).

Build green · 256/256 tests pass (8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
