### PR TITLE
fix: .visc value coercion routes through ToServiceString (dd-MM-yyyy dates)

### DIFF
--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -1457,7 +1457,11 @@ public sealed class Interpreter
             _ => v.ToString() ?? "null",
         };
 
-    private static string AsString(object? v) => v switch { null => "", string s => s, IFormattable f => f.ToString(null, CultureInfo.InvariantCulture), _ => v.ToString() ?? "" };
+    // Coerce a value to the wire string the server's FromServiceString expects. Routes through the
+    // same Client.ToServiceString the attr.Value setter uses, so a value reaching the server via a
+    // quoted hole / ACTION param coerces identically to one assigned through a bare hole — the two
+    // paths must not disagree (temporal types format dd-MM-yyyy, not the invariant MM/dd general pattern).
+    private static string AsString(object? v) => v switch { null => "", string s => s, _ => Vidyano.Client.ToServiceString(v) ?? "" };
 
     /// <summary>Strips one matching pair of surrounding double or single quotes from a <c>??</c> fallback
     /// token, so <c>?? "x"</c> and <c>?? x</c> both yield the literal <c>x</c>. Unbalanced or absent quotes


### PR DESCRIPTION
## Problem

A `.visc` test sending a `DateTimeOffset` to the server failed with:

```
[assert-notification-error] Can't convert '02/01/2025 02:00:00 +00:00' to 'DateTimeOffset'.
```

The value on the wire was the invariant **general** pattern (`MM/dd`, slashes) — but the server's `FromServiceString` expects `dd-MM-yyyy HH:mm:ss.FFFFFFF K` (`01-02-2025 02:00:00.0000000 +00:00`).

## Root cause

`Vidyano.Script` had **two divergent value→wire coercions**:

- **Bare hole** `SET X = {{var}}` → raw object handed to `attr.Value`, whose setter calls `Client.ToServiceString` → **correct** (`dd-MM-yyyy`).
- **Quoted hole** `SET X = "{{var}}"`, **ACTION params**, **SET reference hints**, **EXPECT RHS** → all go through the interpreter's private `AsString`, which used `IFormattable.ToString(null, InvariantCulture)` → **wrong** (`MM/dd` general pattern) for `DateTime`/`DateTimeOffset`/`TimeSpan`.

So the *same* `DateTimeOffset` variable serialized differently depending on whether the hole was bare or quoted.

## Fix

`AsString` now delegates to `Vidyano.Client.ToServiceString` — the single source of truth the `attr.Value` setter already uses. Bare and quoted interpolation now coerce identically.

## Safety

Output is **byte-identical** for every non-temporal type; the only behavioral changes are exactly the bug:

| Type | before | after |
|---|---|---|
| `string` / `int` / `decimal` / `Guid` / `bool` | — | unchanged |
| `DateTime` / `DateTimeOffset` / `TimeSpan` | invariant general (`02/01/2025…`) ❌ | `dd-MM-yyyy…` ✅ |
| `byte[]` | `"System.Byte[]"` | base64 (strict improvement) |
| `null` | `""` | `""` (preserved) |

Built-in `{{@today}}` / `{{@now}}` already emit pre-formatted strings, so they pass through unchanged — no sample regresses. `FormatValue` (diagnostic-only error text) deliberately left untouched. Build clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)