### PR TITLE
fix: .visc string `\`-continuation works on CRLF files

### DIFF
--- a/Vidyano.Script.LanguageServer/ViscLanguageService.cs
+++ b/Vidyano.Script.LanguageServer/ViscLanguageService.cs
@@ -272,6 +272,7 @@ public sealed class ViscLanguageService
                     if (i + 1 < text.Length)
                     {
                         if (text[i + 1] == '\n') { i++; line++; col = 0; }
+                        else if (text[i + 1] == '\r' && i + 2 < text.Length && text[i + 2] == '\n') { i += 2; line++; col = 0; }
                         else { i++; col += 2; }
                     }
                     else

--- a/Vidyano.Script.Tests/LexerStringContinuationTests.cs
+++ b/Vidyano.Script.Tests/LexerStringContinuationTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Linq;
+using Vidyano.Script.Diagnostics;
+using Vidyano.Script.Parsing;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// A backslash before a literal newline continues a string literal onto the next source line. This must
+/// behave identically on LF and CRLF files — a Windows-authored (CRLF) script previously had its CR consumed
+/// as the escaped char, leaving the bare LF to end the string and report it as unterminated. See
+/// <c>Lexer.ReadString</c>.
+/// </summary>
+public sealed class LexerStringContinuationTests
+{
+    private static (Token Str, IReadOnlyList<Diagnostic> Diagnostics) Lex(string source)
+    {
+        var lexer = new Lexer(source, "<test>");
+        var tokens = lexer.Tokenize();
+        return (tokens.First(t => t.Kind == TokenKind.String), lexer.Diagnostics);
+    }
+
+    [Fact]
+    public void Crlf_Continuation_DecodesLikeLf_AndIsNotUnterminated()
+    {
+        var (lf, lfDiags) = Lex("\"a\\\nb\"");
+        var (crlf, crlfDiags) = Lex("\"a\\\r\nb\"");
+
+        Assert.DoesNotContain(lfDiags, d => d.Kind == ErrorKind.ParseUnterminatedString);
+        Assert.DoesNotContain(crlfDiags, d => d.Kind == ErrorKind.ParseUnterminatedString);
+        Assert.Equal("a\nb", (string?)lf.Value);     // LF continuation already worked
+        Assert.Equal(lf.Value, crlf.Value);           // CRLF must decode identically: CR dropped, single '\n'
+    }
+
+    [Fact]
+    public void Crlf_Continuation_AcrossMultipleLines_JoinsWithSingleNewlines()
+    {
+        var (str, diags) = Lex("\"x \\\r\ny \\\r\nz\"");
+
+        Assert.DoesNotContain(diags, d => d.Kind == ErrorKind.ParseUnterminatedString);
+        Assert.Equal("x \ny \nz", (string?)str.Value);
+    }
+
+    [Fact]
+    public void BareCrlf_WithoutBackslash_StillEndsString_AsUnterminated()
+    {
+        // The fix is scoped to `\`-preceded newlines; an unescaped CRLF still terminates the string.
+        var (_, diags) = Lex("\"abc\r\nDEF");
+
+        Assert.Contains(diags, d => d.Kind == ErrorKind.ParseUnterminatedString);
+    }
+}

--- a/Vidyano.Script.Tests/LexerStringContinuationTests.cs
+++ b/Vidyano.Script.Tests/LexerStringContinuationTests.cs
@@ -50,4 +50,19 @@ public sealed class LexerStringContinuationTests
 
         Assert.Contains(diags, d => d.Kind == ErrorKind.ParseUnterminatedString);
     }
+
+    [Fact]
+    public void Continuation_AdvancesLineTracking_SoTokensAfterTheStringAreOnTheRightLine()
+    {
+        // A token after a `\`-continued string must report its true physical line. Source spans three lines:
+        //   line 1: "a\
+        //   line 2: b"
+        //   line 3: Z
+        static int LineOfZ(string src) =>
+            new Lexer(src, "<test>").Tokenize()
+                .First(t => t.Kind == TokenKind.Identifier && t.Lexeme == "Z").Location.Line;
+
+        Assert.Equal(3, LineOfZ("\"a\\\nb\"\nZ"));        // LF
+        Assert.Equal(3, LineOfZ("\"a\\\r\nb\"\r\nZ"));    // CRLF parity
+    }
 }

--- a/Vidyano.Script.Tests/SemanticTokensTests.cs
+++ b/Vidyano.Script.Tests/SemanticTokensTests.cs
@@ -243,6 +243,18 @@ public sealed class SemanticTokensTests
     }
 
     [Fact]
+    public async Task BackslashBeforeCrlfInString_ContinuesString_SoFollowingHashIsNotAComment()
+    {
+        // CRLF parity with the LF case above: on a Windows-authored (CRLF) file `\`+`\r\n` is the same string
+        // continuation, so the next line's '#' is string content, not a comment. The earlier code consumed the
+        // CR, reset string state at the bare LF, and mis-colored the '#' — the dropped-comment re-scan must keep
+        // string state across the whole CRLF, matching the lexer.
+        var spans = await Tokenize("SET X = \"a\\\r\n# b\"");
+
+        Assert.DoesNotContain(spans, s => s.TokenTypeIndex == Comment);
+    }
+
+    [Fact]
     public async Task StepHeader_ColorsAsCommentToEol()
     {
         var spans = await Tokenize("### Section one\nOPEN Query Customers");

--- a/Vidyano.Script/Parsing/Lexer.cs
+++ b/Vidyano.Script/Parsing/Lexer.cs
@@ -177,6 +177,14 @@ public sealed class Lexer
                     _pos++; _col++; // step over the CR onto the LF
                     esc = '\n';
                 }
+                // A continued *literal* newline (esc is the LF char) advances the source line so tokens after a
+                // multi-line string report the right position. The `\n` escape sequence is distinct — its esc is
+                // the letter 'n', so it does not trip this and stays on one source line.
+                if (esc == '\n')
+                {
+                    _line++;
+                    _col = 0; // the trailing _pos++/_col++ lands col on 1 of the new line
+                }
                 // `\{` / `\}` escape a literal brace so an author can write a literal {{ that is not a hole.
                 var decoded = esc switch { 'n' => '\n', 't' => '\t', 'r' => '\r', '"' => '"', '\\' => '\\', '{' => '{', '}' => '}', _ => esc };
                 sb.Append(decoded);

--- a/Vidyano.Script/Parsing/Lexer.cs
+++ b/Vidyano.Script/Parsing/Lexer.cs
@@ -168,6 +168,15 @@ public sealed class Lexer
             {
                 _pos++; _col++;
                 var esc = _source[_pos];
+                // A backslash before a CRLF newline drops the CR so continuation behaves the same as `\`+`\n`:
+                // on either line ending the string carries onto the next line with a single '\n' in the value.
+                // Without this a CRLF (Windows-authored) file ends the string at the bare LF and reports it as
+                // unterminated.
+                if (esc == '\r' && Peek(1) == '\n')
+                {
+                    _pos++; _col++; // step over the CR onto the LF
+                    esc = '\n';
+                }
                 // `\{` / `\}` escape a literal brace so an author can write a literal {{ that is not a hole.
                 var decoded = esc switch { 'n' => '\n', 't' => '\t', 'r' => '\r', '"' => '"', '\\' => '\\', '{' => '{', '}' => '}', _ => esc };
                 sb.Append(decoded);


### PR DESCRIPTION
## What

A backslash before a newline continues a `.visc` string onto the next source line. That worked on LF files but **broke on CRLF (Windows-authored) files**: the `\` escaped the CR, the bare LF then ended the string, and the script got a spurious *unterminated string* error.

This came out of a Gemini review comment on #20 (now merged). The semantic-token mirror's CRLF handling can only be correct once the **lexer** continues on CRLF — so this fixes the lexer first, then brings the mirror in line.

## How

- **`Lexer.ReadString`** — when `\` is followed by `\r\n`, drop the CR so continuation behaves exactly like `\`+`\n`: the string carries onto the next line with a single `\n` in the decoded value, no diagnostic.
- **Line/column tracking** — a continued *literal* newline now advances the source line, so tokens (and diagnostics) after a multi-line string report the right position. This also corrected a latent semantic-token mis-placement after multi-line strings. (Added per review on this PR; affected LF too.) The `\n` *escape sequence* is unaffected — it stays on one source line.
- **`ViscLanguageService.AddDroppedComments`** — the dropped-`#…EOL`-comment re-scan must track the same string state as the lexer; extend its continuation branch to CRLF so a `#` on a continued line stays string content instead of being mis-colored as a comment. (This is the change Gemini flagged on #20 — faithful now that the lexer continues.)

## Tests

- `LexerStringContinuationTests` — CRLF decodes identically to LF (single- and multi-line), no unterminated diagnostic; a *bare* CRLF (no `\`) still terminates; a token after a multi-line string reports the right line (LF + CRLF).
- `SemanticTokensTests.BackslashBeforeCrlfInString_…` — CRLF parity with the existing LF test: the continued line's `#` is not a comment span.
- Full suite: **304/304** (net8.0), +5 over baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
