### PR TITLE
feat: .visc lint catches undeclared {{x}} variable reads

### DIFF
--- a/Vidyano.Script.Tool/LintCommand.cs
+++ b/Vidyano.Script.Tool/LintCommand.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Spectre.Console;
@@ -5,25 +8,40 @@ using Vidyano.Script;
 
 namespace Vidyano.Script.Tool;
 
-/// <summary><c>vidyano lint &lt;file&gt;</c> — parse-check a .visc without executing it.</summary>
+/// <summary><c>vidyano lint &lt;file&gt;</c> — parse-check a .visc without executing it, plus a
+/// presence-only check for <c>{{x}}</c> reads of undeclared variables. <c>--var</c> / <c>--env-prefix</c>
+/// names are forwarded as "expected" so a parameterized script isn't flagged for values it gets at run time.</summary>
 public static class LintCommand
 {
     public static Task<int> ExecuteAsync(string[] args)
     {
         if (args.Length == 0 || Cli.IsHelpFlag(args[0]))
         {
-            AnsiConsole.MarkupLine("Usage: [yellow]vidyano lint <file.visc>[/]");
+            AnsiConsole.MarkupLine("Usage: [yellow]vidyano lint <file.visc> [--var k=v] [--env-prefix PREFIX][/]");
             return Task.FromResult(Cli.ExitUsage);
         }
 
-        var path = args[0];
+        var parsed = Args.Parse(args);
+        if (parsed.Unknown.Count > 0)
+        {
+            foreach (var u in parsed.Unknown)
+                AnsiConsole.MarkupLine($"[red]error:[/] {Markup.Escape(u)}");
+            return Task.FromResult(Cli.ExitUsage);
+        }
+        if (parsed.File is null)
+        {
+            AnsiConsole.MarkupLine("[red]error:[/] no .visc file given");
+            return Task.FromResult(Cli.ExitUsage);
+        }
+
+        var path = parsed.File;
         if (!File.Exists(path))
         {
             AnsiConsole.MarkupLine($"[red]error:[/] file not found: [yellow]{Markup.Escape(path)}[/]");
             return Task.FromResult(Cli.ExitUsage);
         }
 
-        var diags = VidyanoScript.Lint(File.ReadAllText(path), path);
+        var diags = VidyanoScript.Lint(File.ReadAllText(path), path, ExpectedVariables(parsed));
         if (diags.Count == 0)
         {
             AnsiConsole.MarkupLine($"[green]ok[/] {Markup.Escape(path)} (no problems)");
@@ -34,5 +52,18 @@ public static class LintCommand
             ConsoleReporter.WriteDiagnostic(d);
         AnsiConsole.MarkupLine($"[red]{diags.Count} problem(s)[/] in {Markup.Escape(path)}");
         return Task.FromResult(Cli.ExitLint);
+    }
+
+    /// <summary>The variable names the run would supply externally: explicit <c>--var</c> keys plus the
+    /// process-env names <c>--env-prefix</c> would bulk-bind (prefix stripped), mirroring the engine's
+    /// own binding so a script that reads <c>{{REGION}}</c> off <c>VIDYANO_REGION</c> isn't flagged.</summary>
+    private static IEnumerable<string> ExpectedVariables(Args parsed)
+    {
+        var names = new List<string>(parsed.Vars.Keys);
+        if (parsed.EnvironmentPrefix is { Length: > 0 } prefix)
+            foreach (DictionaryEntry e in Environment.GetEnvironmentVariables())
+                if (e.Key is string k && k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && k.Length > prefix.Length)
+                    names.Add(k.Substring(prefix.Length));
+        return names;
     }
 }

--- a/Vidyano.Script/Diagnostics/VariableUseAnalyzer.cs
+++ b/Vidyano.Script/Diagnostics/VariableUseAnalyzer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Vidyano.Script.Parsing;
+
+namespace Vidyano.Script.Diagnostics;
+
+/// <summary>
+/// Static, presence-only check for variable READS that reference a name nothing supplies — neither a
+/// script declaration nor a caller-provided value. It complements the two existing layers: the parser
+/// is purely syntactic and never looks at names, and the interpreter loud-fails an undeclared
+/// <c>{{x}}</c> only when it actually evaluates it. Linting closes the gap by catching the typo up
+/// front (before a connection is opened), while the interpreter stays the control-flow-aware backstop.
+/// </summary>
+/// <remarks>
+/// <para><b>Presence-only.</b> Order is ignored — a <c>{{x}}</c> written above its <c>@x = …</c> is
+/// accepted because the binding exists <em>somewhere</em>. The analyzer also can't see control flow, so
+/// it deliberately stays advisory: a read reachable only inside a <c>REQUIRES</c>-skipped body would be
+/// flagged here even though the interpreter would never evaluate it. That's why this feeds
+/// <see cref="VidyanoScript.Lint"/> only and does not gate <see cref="VidyanoScript.RunAsync"/>.</para>
+/// <para><b>Reads are the <c>{{x}}</c> form only.</b> The bare <c>@x</c> syntax is a reserved-scope
+/// reference (<c>@session.attr</c>), which the parser already validates. The non-variable interpolation
+/// forms (<c>{{@today}}</c>, <c>{{@session.X}}</c>, <c>{{env:NAME}}</c>, <c>{{Messages.X}}</c>) resolve
+/// through their own machinery, not the variable table, so they are skipped here.</para>
+/// </remarks>
+internal static class VariableUseAnalyzer
+{
+    /// <summary>Returns one <see cref="ErrorKind.ResolveVariable"/> diagnostic per interpolation that
+    /// reads a plain variable name nothing in <paramref name="script"/> declares and
+    /// <paramref name="externalVariables"/> (caller-supplied via <c>--var</c> / options / env-prefix)
+    /// doesn't provide.</summary>
+    public static IReadOnlyList<Diagnostic> Analyze(ScriptAst script, IEnumerable<string>? externalVariables)
+    {
+        var declared = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (externalVariables is not null)
+            foreach (var name in externalVariables)
+                declared.Add(name);
+
+        // First pass: every name the script binds. `@x =` assignments and TOOL `-> @result` captures
+        // both populate the variable table at runtime, so a later {{x}} / {{result}} is legal.
+        foreach (var step in script.Steps)
+            foreach (var stmt in step.Statements)
+            {
+                if (stmt is VariableAssignment va) declared.Add(va.Name);
+                else if (stmt is ToolCallStmt { ResultVariable: { } rv }) declared.Add(rv);
+            }
+
+        // Second pass: collect every interpolation read, then flag the plain-variable ones whose name
+        // nothing declares.
+        var holes = new List<InterpExpr>();
+        foreach (var step in script.Steps)
+            foreach (var stmt in step.Statements)
+                CollectInterps(stmt, holes);
+
+        var diags = new List<Diagnostic>();
+        foreach (var hole in holes)
+        {
+            var name = hole.Inner.Trim();
+            if (!IsPlainVariable(name) || declared.Contains(name)) continue;
+            diags.Add(new Diagnostic(
+                ErrorKind.ResolveVariable,
+                $"Variable '{name}' is not defined.",
+                hole.Location,
+                Hint: Suggester.Hint(name, declared)
+                      ?? "Declare it with `@name = …`, pass --var name=value, or add it to the expected variables."));
+        }
+        return diags;
+    }
+
+    /// <summary>True when an interpolation body is a plain variable name — not a built-in (<c>@…</c>),
+    /// a scoped attribute read (<c>@scope.attr</c>), an env lookup (<c>env:NAME</c>), or a client-message
+    /// lookup (<c>Messages.X</c>). Mirrors the dispatch order in the interpreter's interpolation evaluator
+    /// so the two never disagree on what counts as a variable.</summary>
+    private static bool IsPlainVariable(string inner)
+    {
+        if (inner.Length == 0) return false;                                            // empty hole — runtime owns that error
+        if (inner[0] == '@') return false;                                              // built-in or @scope.attr
+        if (inner.StartsWith("env:", StringComparison.OrdinalIgnoreCase)) return false; // environment lookup
+        if (inner.StartsWith("Messages.", StringComparison.Ordinal)) return false;      // client-message lookup
+        return true;
+    }
+
+    /// <summary>Accumulates every <see cref="InterpExpr"/> reachable from an AST node. Reflection over
+    /// the parsing records keeps this complete as the grammar grows: a new statement field that can hold
+    /// an expression is traversed without a change here. The AST is an immutable tree, so there are no
+    /// cycles to guard against.</summary>
+    private static void CollectInterps(object? node, List<InterpExpr> sink)
+    {
+        switch (node)
+        {
+            case null:
+            case string:
+                return;
+            case InterpExpr interp:
+                sink.Add(interp); // leaf: Inner is a string, nothing further to descend into
+                return;
+            case IDictionary dict: // ACTION params / TOOL args — IReadOnlyDictionary<string, Expression>
+                foreach (var value in dict.Values) CollectInterps(value, sink);
+                return;
+            case IEnumerable seq: // menu segments, string-interpolation parts, etc.
+                foreach (var item in seq) CollectInterps(item, sink);
+                return;
+        }
+
+        // Descend only into our own AST records; enums, SourceLocation, and primitives are leaves here.
+        var type = node.GetType();
+        if (type.Namespace != "Vidyano.Script.Parsing") return;
+        foreach (var prop in type.GetProperties())
+        {
+            if (prop.GetIndexParameters().Length > 0) continue;
+            CollectInterps(prop.GetValue(node), sink);
+        }
+    }
+}

--- a/Vidyano.Script/Diagnostics/VariableUseAnalyzer.cs
+++ b/Vidyano.Script/Diagnostics/VariableUseAnalyzer.cs
@@ -34,7 +34,8 @@ internal static class VariableUseAnalyzer
         var declared = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (externalVariables is not null)
             foreach (var name in externalVariables)
-                declared.Add(name);
+                if (name is not null) // public API param — an ordinal HashSet throws on a null element
+                    declared.Add(name);
 
         // First pass: every name the script binds. `@x =` assignments and TOOL `-> @result` captures
         // both populate the variable table at runtime, so a later {{x}} / {{result}} is legal.

--- a/Vidyano.Script/VidyanoScript.cs
+++ b/Vidyano.Script/VidyanoScript.cs
@@ -113,14 +113,22 @@ public static class VidyanoScript
         return opts;
     }
 
-    /// <summary>Lints only — returns parse diagnostics without executing.</summary>
-    public static IReadOnlyList<Diagnostic> Lint(string body, string sourcePath = "<inline>")
+    /// <summary>Lints only — returns diagnostics without executing. Parse errors take precedence; when
+    /// the source parses cleanly the script is additionally checked for <c>{{x}}</c> reads of variables
+    /// nothing declares (see <see cref="VariableUseAnalyzer"/>). <paramref name="expectedVariables"/>
+    /// names the variables the caller will supply at run time (<c>--var</c>, options, env-prefix) so a
+    /// parameterized script doesn't false-positive on a value it never declares inline.</summary>
+    public static IReadOnlyList<Diagnostic> Lint(string body, string sourcePath = "<inline>", IEnumerable<string>? expectedVariables = null)
     {
         var lexer = new Lexer(body, sourcePath);
         var tokens = lexer.Tokenize();
         var parser = new Parser(tokens, lexer.Diagnostics);
-        _ = parser.Parse();
-        return parser.Diagnostics;
+        var script = parser.Parse();
+        // A broken AST makes name-resolution diagnostics misleading, so only run the semantic pass once
+        // the source is syntactically clean — same reasoning as RunAsync refusing a partial parse.
+        if (parser.Diagnostics.Count > 0)
+            return parser.Diagnostics;
+        return VariableUseAnalyzer.Analyze(script, expectedVariables);
     }
 
     private static string? PeekAppVar(Parsing.ScriptAst script)


### PR DESCRIPTION
## Summary

`.visc` lint was parse-only, so a `{{y}}` reading a variable nothing declares passed lint clean and only loud-failed at run time once the interpreter evaluated it. This adds a presence-only semantic pass that catches the typo up front.

(Note: the bare `@y` form was already caught — it parses as a reserved-scope reference like `@session.attr`, not a variable read. The gap was exclusively the `{{x}}` interpolation form.)

## What changed

- **`VariableUseAnalyzer`** (new) — runs after a clean parse. Collects the declared set (`@x =` assignments + TOOL `-> @result` captures + caller-supplied names), then flags any `{{x}}` interpolation whose plain name isn't in it. Skips the non-variable interpolation forms (`{{@today}}`, `{{@session.X}}`, `{{env:NAME}}`, `{{Messages.X}}`) to mirror the interpreter's dispatch. Reflection-walks the AST so new grammar is covered without changes here.
- **`VidyanoScript.Lint`** — new optional `expectedVariables` param (source-compatible). Only analyzes when the parse is clean; reuses the `resolve-variable` kind so the message matches the runtime's.
- **CLI `lint`** — now parses shared flags and forwards `--var` keys + `--env-prefix` matches as expected vars, so parameterized scripts don't false-positive.

## Design note: why lint-only, not `RunAsync`

A presence-only check can't see control flow. A `{{x}}` reachable solely inside a `REQUIRES`-skipped body would be a false positive — that script passes today (the read never executes), and gating `RunAsync` on the static check would newly fail it. So `RunAsync` keeps relying on the interpreter's control-flow-aware loud-fail; the analyzer stays advisory (lint-only).

## Verification

- Undeclared `{{y}}` flagged (with did-you-mean); declared, `--var`-supplied, TOOL-result-bound, built-ins, string-interpolation holes, and use-before-assign all behave correctly.
- All 20 sample scripts regression-clean (`errors-demo.visc` still reports its 5 intentional parse errors; the analyzer correctly stays silent when parsing fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
