### PR TITLE
perf: per-request hot path — compression, streaming parse, search-race fix, O(1) cell reads

### DIFF
--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -4,9 +4,11 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -92,6 +94,11 @@ namespace Vidyano
                 {
                     CookieContainer = new(),
                     UseCookies = true,
+#if !NETSTANDARD2_0
+                    AutomaticDecompression = DecompressionMethods.All,
+#else
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+#endif
                 };
 
                 httpClient = new HttpClient(handler)
@@ -298,7 +305,7 @@ namespace Vidyano
             HttpResponseMessage responseMsg;
             try
             {
-                var requestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(Uri) + method) { Content = new StringContent(data.ToString(Formatting.None)) };
+                using var requestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(Uri) + method) { Content = new StringContent(data.ToString(Formatting.None)) };
                 if (AuthorizationHeader != null)
                     requestMessage.Headers.Authorization = AuthorizationHeader;
                 responseMsg = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
@@ -312,14 +319,22 @@ namespace Vidyano
                 return Log(new JObject(new JProperty("exception", GetNoInternetMessage().Message + "\n\nException: " + responseEx)));
             }
 
-            if (!responseMsg.IsSuccessStatusCode)
-                return Log(new JObject(new JProperty("exception", "error, status: " + responseMsg.StatusCode)));
+            JObject response;
+            using (responseMsg)
+            {
+                if (!responseMsg.IsSuccessStatusCode)
+                    return Log(new JObject(new JProperty("exception", "error, status: " + responseMsg.StatusCode)));
 
-            var content = await responseMsg.Content.ReadAsStringAsync().ConfigureAwait(false);
-            if (string.IsNullOrEmpty(content))
-                return Log(new JObject(new JProperty("exception", GetNoInternetMessage().Title)));
+                using var stream = await responseMsg.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                using var streamReader = CreateResponseReader(stream, responseMsg.Content);
+                using var jsonReader = new JsonTextReader(streamReader);
 
-            var response = JObject.Parse(content);
+                // ContentLength is unreliable for chunked responses; an empty body is detected by the reader.
+                if (!await jsonReader.ReadAsync().ConfigureAwait(false))
+                    return Log(new JObject(new JProperty("exception", GetNoInternetMessage().Title)));
+
+                response = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+            }
 
             var ex = (string)response["exception"];
             if (!string.IsNullOrEmpty(ex) && ex == "Session expired")
@@ -329,8 +344,11 @@ namespace Vidyano
                     data.Remove("password");
                     data.Remove("authToken");
 
-                    responseMsg = await httpClient.PostAsync(new Uri(Uri) + method, new StringContent(data.ToString(Formatting.None))).ConfigureAwait(false);
-                    response = JObject.Parse(await responseMsg.Content.ReadAsStringAsync().ConfigureAwait(false));
+                    using var retryResponseMsg = await httpClient.PostAsync(new Uri(Uri) + method, new StringContent(data.ToString(Formatting.None))).ConfigureAwait(false);
+                    using var retryStream = await retryResponseMsg.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    using var retryStreamReader = CreateResponseReader(retryStream, retryResponseMsg.Content);
+                    using var retryJsonReader = new JsonTextReader(retryStreamReader);
+                    response = await JObject.LoadAsync(retryJsonReader).ConfigureAwait(false);
                 }
                 else
                 {
@@ -342,6 +360,25 @@ namespace Vidyano
             DispatchClientOperations(response);
 
             return Log(response);
+        }
+
+        // ReadAsStringAsync honored the Content-Type charset; keep that for non-UTF-8 servers.
+        // An unknown/invalid charset falls back to UTF-8 (with BOM detection) instead of throwing.
+        private static StreamReader CreateResponseReader(Stream stream, HttpContent content)
+        {
+            var charSet = content.Headers.ContentType?.CharSet?.Trim('"');
+            if (!string.IsNullOrEmpty(charSet))
+            {
+                try
+                {
+                    return new StreamReader(stream, Encoding.GetEncoding(charSet));
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+
+            return new StreamReader(stream);
         }
 
         private void DispatchClientOperations(JObject response)

--- a/Vidyano.Core/ViewModel/Query.cs
+++ b/Vidyano.Core/ViewModel/Query.cs
@@ -21,6 +21,7 @@ namespace Vidyano.ViewModel
         private readonly SortedDictionary<int, QueryResultItem> items = new SortedDictionary<int, QueryResultItem>();
         private readonly List<int> queriedPages = new List<int>();
         private QueryColumn[] _Columns;
+        private Dictionary<string, QueryColumn> columnsByName;
         private bool _AllSelected;
         private bool _HasSearched;
         private bool _HasSelectedItems;
@@ -197,7 +198,35 @@ namespace Vidyano.ViewModel
         public QueryColumn[] Columns
         {
             get => _Columns;
-            private set => SetProperty(ref _Columns, value);
+            private set
+            {
+                // First-wins on duplicate names, matching the FirstOrDefault semantics this map replaces.
+                var map = new Dictionary<string, QueryColumn>();
+                if (value != null)
+                {
+                    foreach (var column in value)
+                    {
+                        var name = column.Name;
+                        if (name != null && !map.ContainsKey(name))
+                            map[name] = column;
+                    }
+                }
+
+                // Assign before SetProperty: PropertyChanged fires synchronously, and a handler reading
+                // cells during the notification must never see the new columns paired with the stale map.
+                columnsByName = map;
+
+                SetProperty(ref _Columns, value);
+            }
+        }
+
+        internal QueryColumn GetColumn(string name)
+        {
+            if (name == null)
+                return null;
+
+            columnsByName.TryGetValue(name, out var column);
+            return column;
         }
 
         public QueryAction[] Actions { get; }
@@ -316,11 +345,11 @@ namespace Vidyano.ViewModel
 
         private async Task<bool> SearchAsync(bool resetItems = false)
         {
-            if (searchCancellationTokenSource != null)
-                searchCancellationTokenSource.Cancel();
+            searchCancellationTokenSource?.Cancel();
 
-            searchCancellationTokenSource = new CancellationTokenSource();
-            var token = searchCancellationTokenSource.Token;
+            var cts = new CancellationTokenSource();
+            searchCancellationTokenSource = cts;
+            var token = cts.Token;
 
             try
             {
@@ -352,7 +381,8 @@ namespace Vidyano.ViewModel
             }
             finally
             {
-                searchCancellationTokenSource = null;
+                // Only clear our own CTS; a finishing older search must not clobber a newer search's.
+                Interlocked.CompareExchange(ref searchCancellationTokenSource, null, cts);
             }
 
             return false;

--- a/Vidyano.Core/ViewModel/QueryResultItem.cs
+++ b/Vidyano.Core/ViewModel/QueryResultItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -7,6 +7,7 @@ namespace Vidyano.ViewModel
     public class QueryResultItem : ViewModelBase
     {
         private readonly JArray values;
+        private Dictionary<string, JToken> valuesByKey;
 
         public QueryResultItem(Client client, string id)
             : base(client, new JObject(new JProperty("id", id)))
@@ -34,23 +35,51 @@ namespace Vidyano.ViewModel
         {
             get
             {
-                var column = Query.Columns.FirstOrDefault(c => c.Name == key);
-
-                var value = values.FirstOrDefault(v => (string)v["key"] == key);
+                var value = GetValue(key);
                 if (value != null)
-                    return Client.FromServiceString((string)value["value"], column.Type);
+                {
+                    var column = Query?.GetColumn(key);
+                    return Client.FromServiceString((string)value["value"], column?.Type);
+                }
 
                 return null;
             }
             set
             {
-                var val = values.FirstOrDefault(v => (string)v["key"] == key);
+                var val = GetValue(key);
                 if (val != null)
                 {
                     val["value"] = Client.ToServiceString(value);
                     OnPropertyChanged("Item[]");
                 }
             }
+        }
+
+        // The setter only mutates elements in place (never adds/removes), so the map stays valid once built.
+        private JToken GetValue(string key)
+        {
+            if (key == null)
+                return null;
+
+            if (valuesByKey == null)
+            {
+                // First-wins on duplicate keys, matching the FirstOrDefault semantics this map replaces.
+                var map = new Dictionary<string, JToken>();
+                if (values != null)
+                {
+                    foreach (var value in values)
+                    {
+                        var valueKey = (string)value["key"];
+                        if (valueKey != null && !map.ContainsKey(valueKey))
+                            map[valueKey] = value;
+                    }
+                }
+
+                valuesByKey = map;
+            }
+
+            valuesByKey.TryGetValue(key, out var result);
+            return result;
         }
 
         #endregion


### PR DESCRIPTION
Four verified internal optimizations covering the per-request hot path end to end. No public API changes — all new members are private/internal.

## Changes

1. **Response compression** — the default `HttpClientHandler` now sets `AutomaticDecompression` (`GZip | Deflate` on netstandard2.0, `DecompressionMethods.All` incl. Brotli on net8/net10). Injected `HttpClient`s are untouched.
2. **`PostAsync` streaming parse + disposal** — responses are parsed from the stream via `JsonTextReader` + `JObject.LoadAsync` instead of buffering the whole body into a string (LOH allocation for payloads >~42KB) and re-parsing; `HttpRequestMessage`/`HttpResponseMessage` are now disposed (both leaked before). The reader honors the response `Content-Type` charset like `ReadAsStringAsync` did. All existing error envelopes (timeout, no-internet, non-success status, empty body) and the session-expired retry path keep their semantics; completion option unchanged.
3. **`SearchAsync` race fix (correctness)** — an older search's `finally` unconditionally nulled `searchCancellationTokenSource`, clobbering a newer search's CTS so it could no longer be cancelled and stale results could overwrite newer ones. The field is now cleared with `Interlocked.CompareExchange` only when it still holds that search's own CTS.
4. **`QueryResultItem` indexer O(1)** — cell reads no longer scan `Query.Columns` and the values `JArray` linearly per access (the hottest read path: grid binding, `.visc` `FOR-EACH ROW`). A lazy per-item key map plus a name→column map maintained by the `Columns` setter replace the scans. A value whose key has no matching column now degrades to a raw string instead of throwing `NullReferenceException`, and the id-only public ctor no longer NREs on indexer access.

## Verification

- Spec-conformance audit: 24/24 checklist items OK against the audit spec (OPTIMIZATIONS.md items 1-4, kept out of this PR).
- Independent code review: no blocking findings; both should-fix items (map assignment ordered before the synchronous `PropertyChanged`, charset-aware reader) are included.
- `dotnet build`: green on netstandard2.0 / net8.0 / net10.0.
- `dotnet test Vidyano.Script.Tests`: 343/343 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)