### PR TITLE
perf: view-model hot path — property-spine allocations, O(n) refresh, O(1) Count, streaming GetStream

### DIFF
--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -630,6 +630,11 @@ namespace Vidyano
             }
         }
 
+        /// <summary>
+        ///     Downloads a registered stream from the server. The returned stream reads directly from
+        ///     the live HTTP response: dispose it promptly when done — an undisposed stream keeps the
+        ///     underlying connection open, and faults during reading surface at the reader.
+        /// </summary>
         public async Task<Tuple<Stream, string>> GetStreamAsync(PersistentObject registeredStream) //, string action = null, PersistentObject parent = null, Query query = null, QueryResultItem[] selectedItems = null, Dictionary<string, string> parameters = null)
         {
             try
@@ -645,10 +650,19 @@ namespace Vidyano
                     { new StringContent(data.ToString(Formatting.None)), "data" },
                 };
 
-                var responseMsg = await httpClient.PostAsync(new Uri(Uri) + "GetStream", req).ConfigureAwait(false);
+                using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Uri) + "GetStream") { Content = req };
+                var responseMsg = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+                if (!responseMsg.IsSuccessStatusCode)
+                {
+                    var error = $"GetStream failed: {(int)responseMsg.StatusCode} ({responseMsg.ReasonPhrase})";
+                    responseMsg.Dispose();
+                    throw new Exception(error);
+                }
 
+                // The returned stream reads directly from the live response (ResponseHeadersRead);
+                // disposing responseMsg here would close it, so it is deliberately left undisposed.
                 var stream = await responseMsg.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                return Tuple.Create(stream, responseMsg.Content.Headers.ContentDisposition.FileName ?? responseMsg.Content.Headers.ContentDisposition.FileNameStar);
+                return Tuple.Create(stream, responseMsg.Content.Headers.ContentDisposition?.FileName ?? responseMsg.Content.Headers.ContentDisposition?.FileNameStar);
             }
             catch (Exception e)
             {

--- a/Vidyano.Core/ViewModel/PersistentObject.cs
+++ b/Vidyano.Core/ViewModel/PersistentObject.cs
@@ -350,7 +350,7 @@ namespace Vidyano.ViewModel
             {
                 // First-wins map by Id; null Ids tracked separately so the lookup below stays
                 // byte-equivalent to FirstOrDefault(a => a.Id == attr.Id), including null == null.
-                var serviceAttributesById = new Dictionary<string, PersistentObjectAttribute>();
+                var serviceAttributesById = new Dictionary<string, PersistentObjectAttribute>(result.Attributes.Length);
                 PersistentObjectAttribute firstNullIdServiceAttribute = null;
                 foreach (var a in result.Attributes)
                 {

--- a/Vidyano.Core/ViewModel/PersistentObject.cs
+++ b/Vidyano.Core/ViewModel/PersistentObject.cs
@@ -348,9 +348,26 @@ namespace Vidyano.ViewModel
 
             if (Attributes != null && result.Attributes != null)
             {
+                // First-wins map by Id; null Ids tracked separately so the lookup below stays
+                // byte-equivalent to FirstOrDefault(a => a.Id == attr.Id), including null == null.
+                var serviceAttributesById = new Dictionary<string, PersistentObjectAttribute>();
+                PersistentObjectAttribute firstNullIdServiceAttribute = null;
+                foreach (var a in result.Attributes)
+                {
+                    var id = a.Id;
+                    if (id == null)
+                    {
+                        if (firstNullIdServiceAttribute == null)
+                            firstNullIdServiceAttribute = a;
+                    }
+                    else if (!serviceAttributesById.ContainsKey(id))
+                        serviceAttributesById[id] = a;
+                }
+
                 foreach (var attr in Attributes)
                 {
-                    var serviceAttribute = result.Attributes.FirstOrDefault(a => a.Id == attr.Id);
+                    var attrId = attr.Id;
+                    var serviceAttribute = attrId != null ? (serviceAttributesById.TryGetValue(attrId, out var sa) ? sa : null) : firstNullIdServiceAttribute;
                     if (serviceAttribute != null)
                     {
                         attr.OptionsDirect = serviceAttribute.OptionsDirect;

--- a/Vidyano.Core/ViewModel/Query.cs
+++ b/Vidyano.Core/ViewModel/Query.cs
@@ -19,6 +19,7 @@ namespace Vidyano.ViewModel
     {
         private readonly ObservableCollection<QueryResultItem> _SelectedItems = new ObservableCollection<QueryResultItem>();
         private readonly SortedDictionary<int, QueryResultItem> items = new SortedDictionary<int, QueryResultItem>();
+        private int maxKey = -1; // Highest populated index in items, so Count stays O(1).
         private readonly List<int> queriedPages = new List<int>();
         private QueryColumn[] _Columns;
         private Dictionary<string, QueryColumn> columnsByName;
@@ -358,6 +359,7 @@ namespace Vidyano.ViewModel
                     Skip = 0;
                     Top = PageSize;
                     items.Clear();
+                    maxKey = -1;
                     queriedPages.Clear();
                     AllSelected = false;
                     SelectedItems.Clear();
@@ -431,6 +433,8 @@ namespace Vidyano.ViewModel
                     }
                     catch {}
                 }
+
+                maxKey = Math.Max(maxKey, startIndex + items.Length - 1);
 
                 if (PageSize > 0)
                     queriedPages.AddRange(Enumerable.Range(startIndex / PageSize.Value, Math.Max(1, items.Length / PageSize.Value)));
@@ -624,7 +628,7 @@ namespace Vidyano.ViewModel
             }
         }
 
-        public int Count => items.Count > 0 ? items.Keys.Max() + 1 : 0;
+        public int Count => maxKey + 1;
 
         public event EventHandler<OpenQueryItemEventArgs> OpenItem = delegate { };
         public event EventHandler<NotificationChangedEventArgs> NotificationChanged = delegate { };

--- a/Vidyano.Core/ViewModel/ViewModelBase.cs
+++ b/Vidyano.Core/ViewModel/ViewModelBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 using Vidyano.Common;
@@ -7,6 +8,9 @@ namespace Vidyano.ViewModel
 {
     public abstract class ViewModelBase : NotifyableBase
     {
+        // Bounded: keys are the fixed set of CallerMemberName property names.
+        private static readonly ConcurrentDictionary<string, string> camelCasePropertyNames = new ConcurrentDictionary<string, string>();
+
         protected ViewModelBase(Client client, JObject model)
         {
             Client = client;
@@ -43,8 +47,8 @@ namespace Vidyano.ViewModel
         protected bool SetProperty<T>(T value, [CallerMemberName] String propertyName = null)
         {
             var camelCasePropertyName = GetCamelCasePropertyName(propertyName);
-            var token = value != null ? JToken.FromObject(value) : null;
-            if (Equals(Model[camelCasePropertyName], token)) return false;
+            var token = value != null ? CreateToken(value) : null;
+            if (JToken.DeepEquals(Model[camelCasePropertyName], token)) return false;
 
             Model[camelCasePropertyName] = token;
             OnPropertyChanged(propertyName);
@@ -61,7 +65,30 @@ namespace Vidyano.ViewModel
 
         private static string GetCamelCasePropertyName(string propertyName)
         {
-            return char.ToLowerInvariant(propertyName[0]) + propertyName.Substring(1);
+            return camelCasePropertyNames.GetOrAdd(propertyName, static name => char.ToLowerInvariant(name[0]) + name.Substring(1));
+        }
+
+        // Only types whose JValue representation matches JToken.FromObject exactly; enums and
+        // complex types keep the serializer path (enum→integer conversion, converters).
+        // Note: unlike FromObject, the fast path bypasses JsonConvert.DefaultSettings, so a host
+        // app's global converters/DateTimeZoneHandling do not affect these primitive tokens.
+        private static JToken CreateToken(object value)
+        {
+            return value switch
+            {
+                string s => new JValue(s),
+                bool b => new JValue(b),
+                int i => new JValue(i),
+                long l => new JValue(l),
+                double d => new JValue(d),
+                decimal m => new JValue(m),
+                float f => new JValue(f),
+                DateTime dt => new JValue(dt),
+                DateTimeOffset dto => new JValue(dto),
+                TimeSpan ts => new JValue(ts),
+                Guid g => new JValue(g),
+                _ => JToken.FromObject(value)
+            };
         }
 
         protected virtual string[] GetServiceProperties()


### PR DESCRIPTION
Second batch from the verified optimization audit (items 5-8) — the view-model hot path. All changes are internal; **no public API surface changes**.

## Changes

### 1. `ViewModelBase.GetProperty/SetProperty` allocation churn
The spine of all ~127 property accessors in the library:
- **camelCase property names cached** in a static `ConcurrentDictionary` (bounded — keys are the fixed `CallerMemberName` set; the lambda is `static`, no closure).
- **Primitive fast path**: 11 primitive types (`string`, `bool`, `int`, `long`, `double`, `decimal`, `float`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`) go straight to `new JValue(...)` instead of `JToken.FromObject`, which spins up `JsonSerializer.CreateDefault()` + a `JTokenWriter` per call — even for a `bool`. Enums and complex types keep the serializer path (enum→integer conversion, converters). Equivalence verified empirically against Newtonsoft.Json 13.0.4: identical `JTokenType`, `DeepEquals`, and `ToObject<T>` round-trips for all 11 types.
- **`Equals` → `JToken.DeepEquals`**: the old comparison only value-compared `JValue`s, so array/object-valued properties compared by reference and *always* raised `PropertyChanged`. Intended behavior change: equal containers no longer raise. An exhaustive caller scan found no caller relying on the old behavior (all `if (SetProperty(...))`-gated callers pass scalars; `OptionsDirect` already had its own `SequenceEqual` guard).

### 2. `PersistentObject.RefreshFromResult` O(n²) → O(n)
Runs on every Save, every Refresh, and every `TriggersRefresh` attribute change (per keystroke in data-entry UIs). Per local attribute, `result.Attributes` was rescanned with `FirstOrDefault`, and every `.Id` probe was a JObject lookup + string allocation. Now a first-wins dictionary built once, with `attr.Id` hoisted per iteration. `FirstOrDefault`'s tolerance for duplicate and null Ids is preserved exactly (first null-Id attribute captured separately so the old `null == null` match still works).

### 3. `Query.Count` O(n) → O(1)
`items.Keys.Max() + 1` was a full LINQ pass evaluated at the start of every `GetEnumerator` call and every `Count` poll by virtualizing list controls. Now a `maxKey` field maintained at the dictionary's only two mutation sites (verified by grep): the placement loop in `SetResult` and `items.Clear()` in `SearchAsync`.

### 4. `Client.GetStreamAsync` streams instead of buffering
- `HttpCompletionOption.ResponseHeadersRead` — a large file export is no longer fully buffered in memory before the "stream" is returned, and the 90s client timeout now covers headers rather than the whole download.
- `IsSuccessStatusCode` check with a descriptive error (`GetStream failed: 500 (...)`) — error pages previously surfaced as `NullReferenceException` via the unconditional `ContentDisposition.FileName` dereference; that access is now null-safe.
- The response is deliberately left undisposed on success (the returned stream reads from the live response; it already leaked pre-change, so lifetime is behavior-neutral). The new doc comment spells out the caller contract: dispose the stream promptly.

## Verification

- Four-stage pipeline: implement → independent code review → independent spec-conformance audit (21/21 checks OK) — review verified the `JValue` fast path by executing both paths against the actual Newtonsoft 13.0.4 binary.
- Build: 0 warnings / 0 errors on netstandard2.0, net8.0, net10.0.
- Regression: `Vidyano.Script.Tests` 343/343 pass (exercises Core end-to-end through the script engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
