### PR TITLE
perf: final audit batch — single-serialize bodies, lookup maps, enum caches, URI + cancellation fixes

### DIFF
--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -33,6 +33,50 @@ namespace Vidyano
 
         private static readonly Dictionary<Type, object> defaultValues = new Dictionary<Type, object>();
 
+        private static readonly UTF8Encoding utf8NoBom = new UTF8Encoding(false);
+
+        private static readonly Dictionary<string, Type> clrTypes = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["INT32"] = typeof(int),
+            ["NULLABLEINT32"] = typeof(int?),
+            ["UINT32"] = typeof(uint),
+            ["NULLABLEUINT32"] = typeof(uint?),
+            ["INT16"] = typeof(short),
+            ["NULLABLEINT16"] = typeof(short?),
+            ["UINT16"] = typeof(ushort),
+            ["NULLABLEUINT16"] = typeof(ushort?),
+            ["INT64"] = typeof(long),
+            ["NULLABLEINT64"] = typeof(long?),
+            ["UINT64"] = typeof(ulong),
+            ["NULLABLEUINT64"] = typeof(ulong?),
+            ["DECIMAL"] = typeof(decimal),
+            ["NULLABLEDECIMAL"] = typeof(decimal?),
+            ["DOUBLE"] = typeof(double),
+            ["NULLABLEDOUBLE"] = typeof(double?),
+            ["SINGLE"] = typeof(float),
+            ["NULLABLESINGLE"] = typeof(float?),
+            ["BYTE"] = typeof(byte),
+            ["NULLABLEBYTE"] = typeof(byte?),
+            ["SBYTE"] = typeof(sbyte),
+            ["NULLABLESBYTE"] = typeof(sbyte?),
+            ["TIME"] = typeof(TimeSpan),
+            ["NULLABLETIME"] = typeof(TimeSpan?),
+            ["DATETIME"] = typeof(DateTime),
+            ["DATE"] = typeof(DateTime),
+            ["NULLABLEDATETIME"] = typeof(DateTime?),
+            ["NULLABLEDATE"] = typeof(DateTime?),
+            ["DATETIMEOFFSET"] = typeof(DateTimeOffset),
+            ["NULLABLEDATETIMEOFFSET"] = typeof(DateTimeOffset?),
+            ["BOOLEAN"] = typeof(bool),
+            ["YESNO"] = typeof(bool),
+            ["NULLABLEBOOLEAN"] = typeof(bool?),
+            ["ENUM"] = typeof(Enum), // NOTE: Can't know correct Enum type
+            ["FLAGSENUM"] = typeof(Enum),
+            ["IMAGE"] = typeof(byte[]),
+            ["GUID"] = typeof(Guid),
+            ["NULLABLEGUID"] = typeof(Guid?),
+        };
+
         private static readonly Dictionary<string, NoInternetMessage> noInternetMessages = new Dictionary<string, NoInternetMessage>
         {
             { "en", new NoInternetMessage("Unable to connect to the server.", "Please check your internet connection settings and try again.", "Try again") },
@@ -78,6 +122,9 @@ namespace Vidyano
         private PersistentObject _Application, _Session, _Initial;
         private bool _IsBusy, _IsConnected, _IsUsingDefaultCredentials;
         private KeyValueList<string, string> _Messages;
+        // (source Uri, normalized base) — one immutable pair so the cache swap is a single
+        // atomic reference write; paired fields could be observed torn on weak memory models.
+        private Tuple<string, string> serviceUriCache;
 
         #endregion
 
@@ -246,13 +293,41 @@ namespace Vidyano
             httpClient.CancelPendingRequests();
         }
 
+        // new Uri(...) preserves the pre-change normalization; the appended "/" makes a missing
+        // trailing slash work instead of silently producing https://host/appMethod (404).
+        private string GetServiceUri(string method)
+        {
+            var uri = Uri;
+            var cache = serviceUriCache;
+            if (cache == null || !ReferenceEquals(uri, cache.Item1))
+            {
+                var normalized = new Uri(uri).ToString();
+                cache = Tuple.Create(uri, normalized.EndsWith("/", StringComparison.Ordinal) ? normalized : normalized + "/");
+                serviceUriCache = cache;
+            }
+
+            return cache.Item2 + method;
+        }
+
+        private static HttpContent CreateRequestContent(JObject data)
+        {
+            var stream = new MemoryStream();
+            using (var writer = new JsonTextWriter(new StreamWriter(stream, utf8NoBom, 1024, leaveOpen: true)) { Formatting = Formatting.None })
+                data.WriteTo(writer);
+
+            stream.Position = 0;
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" };
+            return content;
+        }
+
         public async Task<ClientData> GetClientData(string environment = null)
         {
             try
             {
                 IsBusy = true;
 
-                return new ClientData(JObject.Parse(await httpClient.GetStringAsync(new Uri(Uri) + "GetClientData?environment=" + (environment ?? Hooks.Environment)).ConfigureAwait(false)));
+                return new ClientData(JObject.Parse(await httpClient.GetStringAsync(GetServiceUri("GetClientData?environment=" + System.Uri.EscapeDataString(environment ?? Hooks.Environment ?? string.Empty))).ConfigureAwait(false)));
             }
             catch
             {
@@ -305,15 +380,26 @@ namespace Vidyano
             HttpResponseMessage responseMsg;
             try
             {
-                using var requestMessage = new HttpRequestMessage(HttpMethod.Post, new Uri(Uri) + method) { Content = new StringContent(data.ToString(Formatting.None)) };
+                using var requestMessage = new HttpRequestMessage(HttpMethod.Post, GetServiceUri(method)) { Content = CreateRequestContent(data) };
                 if (AuthorizationHeader != null)
                     requestMessage.Headers.Authorization = AuthorizationHeader;
                 responseMsg = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
             }
+#if !NETSTANDARD2_0
+            catch (TaskCanceledException tce) when (tce.InnerException is TimeoutException)
+            {
+                return Log(new JObject(new JProperty("exception", "Timeout: request took longer than " + httpClient.Timeout)));
+            }
+            catch (TaskCanceledException)
+            {
+                return Log(new JObject(new JProperty("exception", "Cancelled: the request was cancelled")));
+            }
+#else
             catch (TaskCanceledException)
             {
                 return Log(new JObject(new JProperty("exception", "Timeout: request took longer than " + httpClient.Timeout)));
             }
+#endif
             catch (Exception responseEx)
             {
                 return Log(new JObject(new JProperty("exception", GetNoInternetMessage().Message + "\n\nException: " + responseEx)));
@@ -344,7 +430,7 @@ namespace Vidyano
                     data.Remove("password");
                     data.Remove("authToken");
 
-                    using var retryResponseMsg = await httpClient.PostAsync(new Uri(Uri) + method, new StringContent(data.ToString(Formatting.None))).ConfigureAwait(false);
+                    using var retryResponseMsg = await httpClient.PostAsync(GetServiceUri(method), CreateRequestContent(data)).ConfigureAwait(false);
                     using var retryStream = await retryResponseMsg.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     using var retryStreamReader = CreateResponseReader(retryStream, retryResponseMsg.Content);
                     using var retryJsonReader = new JsonTextReader(retryStreamReader);
@@ -647,10 +733,10 @@ namespace Vidyano
 
                 var req = new MultipartFormDataContent("VidyanoBoundary")
                 {
-                    { new StringContent(data.ToString(Formatting.None)), "data" },
+                    { CreateRequestContent(data), "data" },
                 };
 
-                using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Uri) + "GetStream") { Content = req };
+                using var request = new HttpRequestMessage(HttpMethod.Post, GetServiceUri("GetStream")) { Content = req };
                 var responseMsg = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
                 if (!responseMsg.IsSuccessStatusCode)
                 {
@@ -718,7 +804,7 @@ namespace Vidyano
                 data["action"] = action;
                 data["query"] = query?.ToServiceObject();
                 data["parent"] = parent?.ToServiceObject();
-                data["selectedItems"] = selectedItems != null ? JArray.FromObject(selectedItems.Select(i => i?.ToServiceObject())) : null;
+                data["selectedItems"] = selectedItems != null ? new JArray(selectedItems.Select(i => i?.ToServiceObject())) : null;
                 var jParameters = parameters != null ? JObject.FromObject(parameters) : null;
                 data["parameters"] = jParameters;
 
@@ -875,117 +961,7 @@ namespace Vidyano
             if (string.IsNullOrEmpty(type))
                 return typeof(string);
 
-            switch (type.ToUpperInvariant())
-            {
-                case "INT32":
-                    return typeof(int);
-
-                case "NULLABLEINT32":
-                    return typeof(int?);
-
-                case "UINT32":
-                    return typeof(uint);
-
-                case "NULLABLEUINT32":
-                    return typeof(uint?);
-
-                case "INT16":
-                    return typeof(short);
-
-                case "NULLABLEINT16":
-                    return typeof(short?);
-
-                case "UINT16":
-                    return typeof(ushort);
-
-                case "NULLABLEUINT16":
-                    return typeof(ushort?);
-
-                case "INT64":
-                    return typeof(long);
-
-                case "NULLABLEINT64":
-                    return typeof(long?);
-
-                case "UINT64":
-                    return typeof(ulong);
-
-                case "NULLABLEUINT64":
-                    return typeof(ulong?);
-
-                case "DECIMAL":
-                    return typeof(decimal);
-
-                case "NULLABLEDECIMAL":
-                    return typeof(decimal?);
-
-                case "DOUBLE":
-                    return typeof(double);
-
-                case "NULLABLEDOUBLE":
-                    return typeof(double?);
-
-                case "SINGLE":
-                    return typeof(float);
-
-                case "NULLABLESINGLE":
-                    return typeof(float?);
-
-                case "BYTE":
-                    return typeof(byte);
-
-                case "NULLABLEBYTE":
-                    return typeof(byte?);
-
-                case "SBYTE":
-                    return typeof(sbyte);
-
-                case "NULLABLESBYTE":
-                    return typeof(sbyte?);
-
-                case "TIME":
-                    return typeof(TimeSpan);
-
-                case "NULLABLETIME":
-                    return typeof(TimeSpan?);
-
-                case "DATETIME":
-                case "DATE":
-                    return typeof(DateTime);
-
-                case "NULLABLEDATETIME":
-                case "NULLABLEDATE":
-                    return typeof(DateTime?);
-
-                case "DATETIMEOFFSET":
-                    return typeof(DateTimeOffset);
-
-                case "NULLABLEDATETIMEOFFSET":
-                    return typeof(DateTimeOffset?);
-
-                case "BOOLEAN":
-                case "YESNO":
-                    return typeof(bool);
-
-                case "NULLABLEBOOLEAN":
-                    return typeof(bool?);
-
-                case "ENUM":
-                case "FLAGSENUM":
-                    return typeof(Enum); // NOTE: Can't know correct Enum type
-
-                case "IMAGE":
-                    return typeof(byte[]);
-
-                case "GUID":
-                    return typeof(Guid);
-
-                case "NULLABLEGUID":
-                    return typeof(Guid?);
-
-                default:
-                    return typeof(string);
-            }
+            return clrTypes.TryGetValue(type, out var clrType) ? clrType : typeof(string);
         }
 
         public static object FromServiceString(string value, string typeName)

--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -299,7 +299,7 @@ namespace Vidyano
         {
             var uri = Uri;
             var cache = serviceUriCache;
-            if (cache == null || !ReferenceEquals(uri, cache.Item1))
+            if (cache == null || uri != cache.Item1)
             {
                 var normalized = new Uri(uri).ToString();
                 cache = Tuple.Create(uri, normalized.EndsWith("/", StringComparison.Ordinal) ? normalized : normalized + "/");
@@ -386,16 +386,16 @@ namespace Vidyano
                 responseMsg = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
             }
 #if !NETSTANDARD2_0
-            catch (TaskCanceledException tce) when (tce.InnerException is TimeoutException)
+            catch (OperationCanceledException oce) when (oce.InnerException is TimeoutException)
             {
                 return Log(new JObject(new JProperty("exception", "Timeout: request took longer than " + httpClient.Timeout)));
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 return Log(new JObject(new JProperty("exception", "Cancelled: the request was cancelled")));
             }
 #else
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 return Log(new JObject(new JProperty("exception", "Timeout: request took longer than " + httpClient.Timeout)));
             }

--- a/Vidyano.Core/ViewModel/Actions/ActionBase.cs
+++ b/Vidyano.Core/ViewModel/Actions/ActionBase.cs
@@ -185,7 +185,9 @@ namespace Vidyano.ViewModel.Actions
 
         internal static ActionBase GetAction(Client client, Definition definition, PersistentObject parent, Query query = null)
         {
-            var constructor = actionConstructors.GetOrAdd(definition.Name + ";" + (query == null), n =>
+            // The hooks type is part of the key: resolution walks client.Hooks.GetType()'s assembly
+            // chain, so Hooks subclasses from different assemblies must not share a cached constructor.
+            var constructor = actionConstructors.GetOrAdd(definition.Name + ";" + (query == null) + ";" + client.Hooks.GetType().AssemblyQualifiedName, n =>
             {
                 var hooksType = client.Hooks.GetType();
                 var actionType = hooksType.GetTypeInfo().Assembly.GetType("Vidyano.ViewModel.Actions." + definition.Name);

--- a/Vidyano.Core/ViewModel/PersistentObject.cs
+++ b/Vidyano.Core/ViewModel/PersistentObject.cs
@@ -12,6 +12,11 @@ namespace Vidyano.ViewModel
     [DebuggerDisplay("PersistentObject {Type}")]
     public class PersistentObject : ViewModelBase
     {
+        private readonly Dictionary<string, PersistentObjectAttribute> attributesByName;
+        private readonly Dictionary<string, ActionBase> actionsByName, pinnedActionsByName;
+        private NotificationType? notificationType;
+        private StateBehavior? stateBehavior;
+
         internal PersistentObject(Client client, JObject model)
             : base(client, model)
         {
@@ -31,6 +36,17 @@ namespace Vidyano.ViewModel
             }
             else
                 Attributes = Array.Empty<PersistentObjectAttribute>();
+
+            // First-wins on duplicate names, matching the FirstOrDefault semantics this map replaces.
+            // Built as soon as Attributes is final: hooks firing during the Query/Tab construction
+            // below may already resolve attributes through GetAttribute.
+            attributesByName = new Dictionary<string, PersistentObjectAttribute>(Attributes.Length);
+            foreach (var attribute in Attributes)
+            {
+                var name = attribute.Name;
+                if (name != null && !attributesByName.ContainsKey(name))
+                    attributesByName[name] = attribute;
+            }
 
             if (model.TryGetValue("queries", out var queriesToken))
             {
@@ -77,6 +93,24 @@ namespace Vidyano.ViewModel
             }
             else
                 Actions = PinnedActions = Array.Empty<ActionBase>();
+
+            // First-wins on duplicate names, matching the FirstOrDefault semantics these maps replace.
+            // Built before the IsInEdit assignment below: its setter resolves actions through GetAction.
+            actionsByName = new Dictionary<string, ActionBase>(Actions.Length);
+            foreach (var action in Actions)
+            {
+                var name = action.Name;
+                if (name != null && !actionsByName.ContainsKey(name))
+                    actionsByName[name] = action;
+            }
+
+            pinnedActionsByName = new Dictionary<string, ActionBase>(PinnedActions.Length);
+            foreach (var action in PinnedActions)
+            {
+                var name = action.Name;
+                if (name != null && !pinnedActionsByName.ContainsKey(name))
+                    pinnedActionsByName[name] = action;
+            }
 
             // Also check IsInEdit (Object could have been reconstructed after suspend/resume)
             IsInEdit = IsInEdit || IsNew || StateBehavior.HasFlag(StateBehavior.OpenInEdit) || StateBehavior.HasFlag(StateBehavior.StayInEdit);
@@ -141,8 +175,14 @@ namespace Vidyano.ViewModel
 
         public NotificationType NotificationType
         {
-            get { return (NotificationType)Enum.Parse(typeof(NotificationType), GetProperty<string>()); }
-            private set { SetProperty(value.ToString()); }
+            get { return notificationType ??= (NotificationType)Enum.Parse(typeof(NotificationType), GetProperty<string>()); }
+            private set
+            {
+                // Cache before SetProperty: PropertyChanged fires synchronously and a handler
+                // reading this property during the notification must see the new value.
+                notificationType = value;
+                SetProperty(value.ToString());
+            }
         }
 
         public bool HasNotification
@@ -153,7 +193,7 @@ namespace Vidyano.ViewModel
 
         public StateBehavior StateBehavior
         {
-            get { return (StateBehavior)Enum.Parse(typeof(StateBehavior), GetProperty<string>()); }
+            get { return stateBehavior ??= (StateBehavior)Enum.Parse(typeof(StateBehavior), GetProperty<string>()); }
         }
 
         public string Type
@@ -463,12 +503,23 @@ namespace Vidyano.ViewModel
 
         public ActionBase GetAction(string actionName)
         {
-            return Actions.FirstOrDefault(a => a.Name == actionName) ?? PinnedActions.FirstOrDefault(a => a.Name == actionName);
+            if (actionName == null)
+                return null;
+
+            if (actionsByName.TryGetValue(actionName, out var action))
+                return action;
+
+            pinnedActionsByName.TryGetValue(actionName, out action);
+            return action;
         }
 
         public PersistentObjectAttribute GetAttribute(string attributeName)
         {
-            return Attributes.FirstOrDefault(a => a.Name == attributeName);
+            if (attributeName == null)
+                return null;
+
+            attributesByName.TryGetValue(attributeName, out var attribute);
+            return attribute;
         }
 
         public object GetAttributeValue(string attributeName)
@@ -503,7 +554,7 @@ namespace Vidyano.ViewModel
             if (Parent != null)
                 jObj["parent"] = Parent.ToServiceObject();
 
-            jObj["attributes"] = JArray.FromObject(Attributes.Select(attr => attr.ToServiceObject()));
+            jObj["attributes"] = new JArray(Attributes.Select(attr => attr.ToServiceObject()));
 
             return jObj;
         }

--- a/Vidyano.Core/ViewModel/PersistentObjectAttribute.cs
+++ b/Vidyano.Core/ViewModel/PersistentObjectAttribute.cs
@@ -18,6 +18,7 @@ namespace Vidyano.ViewModel
 
         private Option[] _Options;
         private volatile KeyValueList<string, string> _TypeHints;
+        private AttributeVisibility? visibility;
         protected string[] propertiesToBackup = { "value", "isReadOnly", "isValueChanged", "options", "validationError" };
 
         private static readonly Task<bool> getFalse;
@@ -201,9 +202,12 @@ namespace Vidyano.ViewModel
 
         internal AttributeVisibility Visibility
         {
-            get => (AttributeVisibility)Enum.Parse(typeof(AttributeVisibility), GetProperty<string>());
+            get => visibility ??= (AttributeVisibility)Enum.Parse(typeof(AttributeVisibility), GetProperty<string>());
             set
             {
+                // Cache before SetProperty: PropertyChanged fires synchronously and a handler
+                // reading this property during the notification must see the new value.
+                visibility = value;
                 if (SetProperty(value.ToString()))
                     OnPropertyChanged("IsVisible");
             }

--- a/Vidyano.Core/ViewModel/Query.cs
+++ b/Vidyano.Core/ViewModel/Query.cs
@@ -28,6 +28,7 @@ namespace Vidyano.ViewModel
         private bool _HasSelectedItems;
         private bool _HasTextSearch;
         private int _TotalItems;
+        private NotificationType? notificationType;
         private CancellationTokenSource searchCancellationTokenSource;
         private Task<bool> searchingTask;
         private PersistentObjectTabQuery[] semanticZoomTabs;
@@ -113,8 +114,14 @@ namespace Vidyano.ViewModel
 
         public NotificationType NotificationType
         {
-            get => (NotificationType)Enum.Parse(typeof(NotificationType), GetProperty<string>());
-            private set => SetProperty(value.ToString());
+            get => notificationType ??= (NotificationType)Enum.Parse(typeof(NotificationType), GetProperty<string>());
+            private set
+            {
+                // Cache before SetProperty: PropertyChanged fires synchronously and a handler
+                // reading this property during the notification must see the new value.
+                notificationType = value;
+                SetProperty(value.ToString());
+            }
         }
 
         public bool HasNotification
@@ -398,14 +405,14 @@ namespace Vidyano.ViewModel
                 Columns = columns.Select(jCol =>
                 {
                     var column = new QueryColumn((JObject)jCol, this);
-                    if (Columns != null)
+                    var name = column.Name;
+                    // columnsByName still holds the previous columns here; the new array is only
+                    // assigned (and the map rebuilt) after this Select completes.
+                    var sourceColumn = GetColumn(name);
+                    if (sourceColumn != null)
                     {
-                        var sourceColumn = Columns.FirstOrDefault(c => c.Name == column.Name);
-                        if (sourceColumn != null)
-                        {
-                            column.Includes = sourceColumn.Includes;
-                            column.Excludes = sourceColumn.Excludes;
-                        }
+                        column.Includes = sourceColumn.Includes;
+                        column.Excludes = sourceColumn.Excludes;
                     }
                     return column;
                 }).ToArray();
@@ -604,7 +611,7 @@ namespace Vidyano.ViewModel
                 jObj["persistentObject"] = PersistentObject.ToServiceObject();
 
             if (Columns != null)
-                jObj["columns"] = JArray.FromObject(Columns.Select(col => col.ToServiceObject()));
+                jObj["columns"] = new JArray(Columns.Select(col => col.ToServiceObject()));
 
             // Emit only when set (mirrors the server's EmitDefaultValue=false): allSelected=true tells the
             // server to operate on the full result set, treating any posted selectedItems as exclusions.


### PR DESCRIPTION
Final batch from the verified optimization audit (items 9–17). All changes are internal; **no public API surface changes**.

## Changes

1. **`new JArray(...)` instead of `JArray.FromObject(...)`** for the three sites that feed already-fresh, unparented service `JObject`s (PO attributes, query columns, selectedItems) — `FromObject` allocated a `JsonSerializer` and deep-copied tokens the `JArray` ctor simply adopts. Byte-identical JSON; the `columnOverrides` POCO sites deliberately keep `FromObject`.
2. **Request bodies serialize once** — `data.ToString(Formatting.None)` (full UTF-16 string) + `StringContent` (UTF-8 re-encode) is now a single `JsonTextWriter → StreamWriter → MemoryStream → StreamContent` pass, with the Content-Type header byte-identical (`text/plain; charset=utf-8`, no BOM). Applies to `PostAsync`, its retry, and `GetStream`'s multipart part.
3. **`GetClrType`**: static `Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)` replaces the `switch (type.ToUpperInvariant())` that allocated a string per conversion (every attribute/cell read). All 38 mappings verified one-by-one, including Turkish-I equivalence with the old invariant-uppercase matching.
4. **`PersistentObject.GetAttribute`/`GetAction`**: ctor-built first-wins name maps replace linear scans (the `IsInEdit` setter alone did three `GetAction` scans per transition). The arrays are get-only and only their elements mutate, so the maps can never go stale.
5. **Enum parse caching** for `NotificationType` (PO + Query), `StateBehavior`, and `AttributeVisibility` — non-generic `Enum.Parse` + boxing per read, gone. Caches are written *before* `SetProperty` because `PropertyChanged` fires synchronously; throw-on-invalid getter behavior preserved. All write paths verified to route through the caching setters (including edit backup/restore).
6. **`Query.SetResult` column merge** O(c²) → O(c): reuses the existing first-wins `columnsByName` map (which still holds the *old* columns at merge time) instead of `FirstOrDefault` per column.
7. **Service URI built from a cached normalized base** with a guaranteed trailing slash — `"https://host/app"` without one silently produced `https://host/appGetQuery` → 404 ("error, status: NotFound"); now it just works. The cache is a single immutable pair swapped by one atomic reference write (review caught that two separate fields could be observed torn on weak memory models). The `environment` query param in `GetClientData` is now `EscapeDataString`'d. The public `Uri` property is untouched.
8. **Cancellation no longer mislabeled as timeout** (net8.0/net10.0): a real timeout carries `InnerException is TimeoutException` and keeps the `Timeout: …` envelope; `CancelPendingServiceCalls()` now reports `Cancelled: the request was cancelled`. netstandard2.0 keeps the old behavior verbatim (on .NET Framework real timeouts have no inner `TimeoutException`, so the split would be wrong there).
9. **`ActionBase` constructor-cache key now includes the Hooks type** (`AssemblyQualifiedName`) — fixes a latent bug where two Clients with `Hooks` subclasses from different assemblies silently shared whichever action constructor resolved first.

## Verification

- Four-stage pipeline: implement → independent code review → independent spec-conformance audit (**31/31 checks OK**). Review independently re-verified the 38 `GetClrType` mappings, the `CreateRequestContent` flush/ownership/encoding chain, ctor-path coverage of the new maps, and that no writer bypasses the enum caches.
- Build: clean on netstandard2.0, net8.0, net10.0.
- Regression: `Vidyano.Script.Tests` **343/343** pass (re-run after the atomic-cache fix).

This completes all 17 verified items from the audit (items 1–4 in #25, 5–8 in #26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
