### PR TITLE
fix: Prevent NRE during sign-in when initial PO carries actions

### DIFF
--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -547,6 +547,20 @@ namespace Vidyano
 
                 Application = po;
 
+                // Populate Actions before constructing the Initial PO below: that PO can carry
+                // actions, which GetActions resolves against this table during construction.
+                Messages = new KeyValueList<string, string>(Application.Queries["ClientMessages"].ToDictionary(item => (string)item["Key"], item => (string)item["Value"]), true);
+                Actions = Application.Queries["Actions"].ToDictionary(item => (string)item["Name"], item => new ActionBase.Definition
+                {
+                    Name = (string)item["Name"],
+                    DisplayName = (string)item["DisplayName"],
+                    IsPinned = (bool)item["IsPinned"],
+                    RefreshQueryOnCompleted = (bool)item["RefreshQueryOnCompleted"],
+                    Offset = (int)item["Offset"],
+                    Options = ((string)item["Options"] ?? string.Empty).Trim().Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(str => str.Trim()).ToArray(),
+                    SelectionRule = ExpressionParser.Get((string)item["SelectionRule"]),
+                });
+
                 if (response["initial"] is JObject initialJson)
                 {
                     var initialPo = Hooks.OnConstruct(this, initialJson);
@@ -560,18 +574,6 @@ namespace Vidyano
                 var cultureInfo = new CultureInfo(Application["Culture"].ValueDirect);
                 CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
                 CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
-
-                Messages = new KeyValueList<string, string>(Application.Queries["ClientMessages"].ToDictionary(item => (string)item["Key"], item => (string)item["Value"]), true);
-                Actions = Application.Queries["Actions"].ToDictionary(item => (string)item["Name"], item => new ActionBase.Definition
-                {
-                    Name = (string)item["Name"],
-                    DisplayName = (string)item["DisplayName"],
-                    IsPinned = (bool)item["IsPinned"],
-                    RefreshQueryOnCompleted = (bool)item["RefreshQueryOnCompleted"],
-                    Offset = (int)item["Offset"],
-                    Options = ((string)item["Options"] ?? string.Empty).Trim().Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(str => str.Trim()).ToArray(),
-                    SelectionRule = ExpressionParser.Get((string)item["SelectionRule"]),
-                });
 
                 await UpdateSession(response).ConfigureAwait(false);
 

--- a/Vidyano.Core/Common/ExpressionParser.cs
+++ b/Vidyano.Core/Common/ExpressionParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Vidyano.Common
 {
@@ -74,7 +75,7 @@ namespace Vidyano.Common
                         }
                     }
 
-                    var number = int.Parse(expression);
+                    var number = int.Parse(expression, CultureInfo.InvariantCulture);
                     switch (op)
                     {
                         case "<":

--- a/Vidyano.Core/ViewModel/Actions/ActionBase.cs
+++ b/Vidyano.Core/ViewModel/Actions/ActionBase.cs
@@ -150,6 +150,11 @@ namespace Vidyano.ViewModel.Actions
         internal static ActionBase[] GetActions(Client client, JToken actionsToken, PersistentObject parent, Query query = null)
         {
             var actions = new List<ActionBase>();
+
+            // client.Actions may be null while a PO is constructed during sign-in; treat as no definitions.
+            if (client.Actions == null)
+                return actions.ToArray();
+
             var actionDefinitions = actionsToken.Select(action =>
             {
                 var actionName = (string)action;

--- a/Vidyano.Script.Tests/SignInInitialActionsTests.cs
+++ b/Vidyano.Script.Tests/SignInInitialActionsTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Http;
+using Vidyano;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Sign-in must not throw when GetApplication returns an initial PO that carries actions.
+/// Drives a real Client over a canned HTTP response.
+/// </summary>
+public sealed class SignInInitialActionsTests
+{
+    // GetApplication response whose initial PO carries a non-empty actions array.
+    private const string GetApplicationResponse = """
+    {
+      "authToken": "test-token",
+      "userName": "admin",
+      "application": {
+        "type": "Application",
+        "fullTypeName": "Vidyano.Application",
+        "stateBehavior": "None",
+        "attributes": [
+          { "name": "Culture", "type": "String", "visibility": "Read", "value": "en-US" }
+        ],
+        "queries": [
+          {
+            "name": "ClientMessages",
+            "result": {
+              "columns": [ { "name": "Key", "type": "String" }, { "name": "Value", "type": "String" } ],
+              "items": []
+            }
+          },
+          {
+            "name": "Actions",
+            "result": {
+              "columns": [
+                { "name": "Name", "type": "String" },
+                { "name": "DisplayName", "type": "String" },
+                { "name": "IsPinned", "type": "Boolean" },
+                { "name": "RefreshQueryOnCompleted", "type": "Boolean" },
+                { "name": "Offset", "type": "Int32" },
+                { "name": "Options", "type": "String" },
+                { "name": "SelectionRule", "type": "String" }
+              ],
+              "items": [
+                {
+                  "id": "0",
+                  "values": [
+                    { "key": "Name", "value": "BulkEdit" },
+                    { "key": "DisplayName", "value": "Bulk Edit" },
+                    { "key": "IsPinned", "value": "false" },
+                    { "key": "RefreshQueryOnCompleted", "value": "false" },
+                    { "key": "Offset", "value": "0" },
+                    { "key": "Options", "value": "" },
+                    { "key": "SelectionRule", "value": "=1" }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "initial": {
+        "type": "Initial",
+        "fullTypeName": "Vidyano.Initial",
+        "stateBehavior": "None",
+        "isHidden": false,
+        "actions": [ "Save" ],
+        "attributes": []
+      }
+    }
+    """;
+
+    private sealed class CannedHandler(string json) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) });
+    }
+
+    [Fact]
+    public async Task SignIn_WithInitialPoCarryingActions_Succeeds_AndPopulatesInitialAndActions()
+    {
+        var client = new Client(new HttpClient(new CannedHandler(GetApplicationResponse))) { Uri = "https://test.local/" };
+
+        // Threw NullReferenceException before the fix.
+        var application = await client.SignInUsingCredentialsAsync("admin", "password");
+
+        // A completed sign-in proves Actions was populated: the trailing Actions["BulkEdit"]
+        // lookup in SignInAsync would otherwise throw.
+        Assert.NotNull(application);
+        Assert.NotNull(client.Initial);
+        Assert.Equal("Vidyano.Initial", client.Initial.FullTypeName);
+        Assert.NotNull(client.Messages);
+    }
+}


### PR DESCRIPTION
The `client.Actions` collection was being populated *after* the initial PersistentObject (PO) was constructed during the sign-in process. If this initial PO contained actions, the `ActionBase.GetActions` method, called during PO construction, would attempt to resolve these actions against a `null` `client.Actions` definition table, leading to a `NullReferenceException`.

This change reorders the initialization to ensure `client.Actions` (and `Messages`) are populated before the initial PO is constructed. Additionally, a null guard was added to `ActionBase.GetActions` for improved robustness. A new test case has been added to verify this specific sign-in scenario.
