### PR TITLE
chore: update NuGet dependencies

### DIFF
--- a/Vidyano.Core/Vidyano.Core.csproj
+++ b/Vidyano.Core/Vidyano.Core.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/Vidyano.Script.Tests/Vidyano.Script.Tests.csproj
+++ b/Vidyano.Script.Tests/Vidyano.Script.Tests.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Vidyano.Script.Tool/Vidyano.Script.Tool.csproj
+++ b/Vidyano.Script.Tool/Vidyano.Script.Tool.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.57.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Routine dependency bumps across the solution. No production code changes.

| Project | Package | From | To | Notes |
|---|---|---|---|---|
| Vidyano.Core | Microsoft.SourceLink.GitHub | 10.0.103 | 10.0.300 | build-only (`PrivateAssets=All`) |
| Vidyano.Script.Tool | Spectre.Console | 0.49.1 | 0.57.0 | no API changes needed |
| Vidyano.Script.Tests | Microsoft.NET.Test.Sdk | 17.11.1 | 18.6.0 | test-only |
| Vidyano.Script.Tests | xunit | 2.9.2 | 2.9.3 | test-only |
| Vidyano.Script.Tests | xunit.runner.visualstudio | 2.8.2 | 3.1.5 | test-only (v3 runner) |

**Left as-is:** `Newtonsoft.Json` (Core) and `OmniSharp.Extensions.LanguageServer` are already on the latest available version. The VS extension SDK and the vscode npm deps are deliberately out of scope (separate ecosystems; the VS SDK is pinned to its toolchain).

### Verification
- `dotnet build` clean across all target frameworks (netstandard2.0 / net8.0 / net10.0), 0 errors.
- `dotnet test` — 346/346 pass on the upgraded test runner.
- CLI smoke: `vidyano lint` and `vidyano help` render correctly on Spectre.Console 0.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)