### PR TITLE
feat: vidyano test suite runner + REPL credential redaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,11 @@ The repository also ships two scripting packages built on top of Vidyano.Core. T
 ### Vidyano.Script.Tool (CLI)
 - Path: `Vidyano.Script.Tool/`
 - Packs as a dotnet tool: `<PackAsTool>true</PackAsTool>`, command name `vidyano`.
-- Subcommands: `run` (execute), `lint` (parse-only), `repl` (interactive), `help` (`help verbs` lists every `.visc` verb).
-- Shared options: `--app`, `--var k=v`, `--mode navigation|audit|direct`, `--tools <path.dll>` (repeatable; loads `IVidyanoScriptToolPack` plugins), `--json` (NDJSON), `--verbose`, `--insecure` (dev TLS only).
-- Exit codes: `0` ok, `1` failed, `2` parse error, `3` connection error, `64` usage.
+- Subcommands: `run` (execute one file), `test` (run a suite), `lint` (parse-only), `repl` (interactive), `lsp` (language server over stdio), `help` (`help verbs` lists every `.visc` verb).
+- Shared options: `--app`, `--var k=v`, `--mode navigation|audit|direct`, `--tools <path.dll>` (repeatable; loads `IVidyanoScriptToolPack` plugins), `--json` (NDJSON; now honored by `lint` too), `--verbose`, `--insecure` (dev TLS only).
+- `run`/`test` add `--timeout <30s|2m|0>` (per-file; off by default). `test` adds positional files/dirs/globs, `--report junit|tap|sarif[:path]` (repeatable), and `--jobs <n>` (parallelism; serial by default). `test` rolls per-file outcomes into one exit code via the pure `SuiteExit.CodeFor`; `run` classifies its single file through the same `SuiteRunner.Classify`, so a no-base-URI script now exits `3` (was `2`).
+- Suite engine lives in `Vidyano.Script/Runtime/`: `SuiteRunner` (per-file executor seam + bounded parallelism + per-file timeout), `SuiteResult`/`FileResult`/`FileOutcome`, pure `SuiteExit.CodeFor`, and `Reporting/` formatters (`IReportFormatter` + JUnit/TAP/SARIF — pure, deterministic, unit-tested in `Vidyano.Script.Tests`). Timing rides additively on `ScriptResult`/`StepResult.Duration` (observational; never in golden compares).
+- Exit codes: `0` ok, `1` failed (incl. timeout), `2` parse error, `3` connection error, `64` usage (incl. no files discovered).
 
 ### `.visc` quick reference
 

--- a/Vidyano.Script.Tests/ReportFormatterTests.cs
+++ b/Vidyano.Script.Tests/ReportFormatterTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Xml.Linq;
+using Vidyano.Script.Runtime;
+using Vidyano.Script.Runtime.Reporting;
+using Xunit;
+using static Vidyano.Script.Tests.SuiteTestData;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>Asserts the exact shape of each machine-readable report for a fabricated pass/fail/skip mix —
+/// no disk, no network. The formatters are pure, so the bytes are deterministic and re-parseable.</summary>
+public sealed class ReportFormatterTests
+{
+    private static SuiteResult Mixed() => Suite(
+        FromScript(Passing("a.visc")),
+        FromScript(Failing("b.visc", message: "Plate already exists")),
+        FromScript(AllSkipped("c.visc")));
+
+    // ---- JUnit ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void JUnit_HasXmlDeclaration_Utf8()
+    {
+        var xml = new JUnitFormatter().Render(Mixed()).Text;
+        Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", xml);
+        Assert.DoesNotContain("\r\n", xml); // deterministic LF endings
+    }
+
+    [Fact]
+    public void JUnit_RootTallies_MatchTheMix()
+    {
+        var doc = XDocument.Parse(new JUnitFormatter().Render(Mixed()).Text);
+        var root = doc.Root!;
+        Assert.Equal("testsuites", root.Name.LocalName);
+        Assert.Equal("vidyano", (string)root.Attribute("name")!);
+        Assert.Equal("3", (string)root.Attribute("tests")!);    // one testcase per step, one step per file
+        Assert.Equal("1", (string)root.Attribute("failures")!);
+        Assert.Equal("0", (string)root.Attribute("errors")!);
+        Assert.Equal("1", (string)root.Attribute("skipped")!);
+    }
+
+    [Fact]
+    public void JUnit_FailingFile_HasFailureWithMessageAndType()
+    {
+        var doc = XDocument.Parse(new JUnitFormatter().Render(Mixed()).Text);
+        var failure = doc.Descendants("testsuite")
+            .Single(s => (string)s.Attribute("name")! == "b.visc")
+            .Descendants("failure").Single();
+        Assert.Equal("Plate already exists", (string)failure.Attribute("message")!);
+        Assert.Equal("assert-failed", (string)failure.Attribute("type")!);
+    }
+
+    [Fact]
+    public void JUnit_SkippedFile_HasSkippedElement()
+    {
+        var doc = XDocument.Parse(new JUnitFormatter().Render(Mixed()).Text);
+        var suite = doc.Descendants("testsuite").Single(s => (string)s.Attribute("name")! == "c.visc");
+        Assert.Single(suite.Descendants("skipped"));
+    }
+
+    [Fact]
+    public void JUnit_FileWithNoResult_BecomesErrorTestcase()
+    {
+        // A timeout/connection file (null Script) contributes one synthetic <error> testcase.
+        var suite = Suite(new FileResult("t.visc", FileOutcome.Timeout, null, TimeSpan.Zero, "timed out after 5s"));
+        var doc = XDocument.Parse(new JUnitFormatter().Render(suite).Text);
+        var error = doc.Descendants("error").Single();
+        Assert.Equal("timed out after 5s", (string)error.Attribute("message")!);
+        Assert.Equal("1", (string)doc.Root!.Attribute("errors")!);
+    }
+
+    // ---- TAP ------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Tap_EmitsVersionPlanAndPoints()
+    {
+        var tap = new TapFormatter().Render(Mixed()).Text;
+        var lines = tap.Split('\n');
+        Assert.Equal("TAP version 13", lines[0]);
+        Assert.Equal("1..3", lines[1]);
+        Assert.Contains("ok 1 - a.visc", tap);
+        Assert.Contains("not ok 2 - b.visc", tap);
+        Assert.Contains("ok 3 - c.visc # SKIP", tap);
+        Assert.Contains("message: \"Plate already exists\"", tap);
+    }
+
+    // ---- SARIF ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Sarif_IsValidJson_WithSchemaAndResults()
+    {
+        var sarif = new SarifFormatter().Render(Mixed()).Text;
+        using var doc = JsonDocument.Parse(sarif);
+        var root = doc.RootElement;
+        Assert.Equal("2.1.0", root.GetProperty("version").GetString());
+        Assert.True(root.TryGetProperty("$schema", out _));
+
+        var run = root.GetProperty("runs")[0];
+        Assert.Equal("vidyano", run.GetProperty("tool").GetProperty("driver").GetProperty("name").GetString());
+
+        var results = run.GetProperty("results");
+        Assert.Equal(1, results.GetArrayLength()); // only the failing file contributes a finding
+        Assert.Equal("assert-failed", results[0].GetProperty("ruleId").GetString());
+        Assert.Equal("Plate already exists", results[0].GetProperty("message").GetProperty("text").GetString());
+    }
+}

--- a/Vidyano.Script.Tests/ScriptSecretsTests.cs
+++ b/Vidyano.Script.Tests/ScriptSecretsTests.cs
@@ -1,0 +1,67 @@
+using Vidyano.Script.Runtime;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>Covers <see cref="ScriptSecrets"/> — the redaction that keeps plaintext credentials out of a
+/// <c>:save</c>d .visc and secret values out of a <c>:vars</c> dump. Span handling is the load-bearing part:
+/// a quoted password's source span differs from its lexeme, so redaction works off token boundaries.</summary>
+public sealed class ScriptSecretsTests
+{
+    [Theory]
+    [InlineData("password", true)]
+    [InlineData("Password", true)]
+    [InlineData("pwd", true)]
+    [InlineData("userToken", true)]
+    [InlineData("apiKey", true)]
+    [InlineData("api_key", true)]
+    [InlineData("clientSecret", true)]
+    [InlineData("authHeader", true)]
+    [InlineData("user", false)]
+    [InlineData("region", false)]
+    [InlineData("app", false)]
+    public void IsSecretName_MatchesSecretLookingNames(string name, bool expected) =>
+        Assert.Equal(expected, ScriptSecrets.IsSecretName(name));
+
+    [Theory]
+    // Bare identifier password.
+    [InlineData("SIGN-IN admin / vidyano", "SIGN-IN admin / {{env:VIDYANO_PASSWORD}}")]
+    // Quoted password (with a space): the source span includes the quotes — boundary-based redaction handles it.
+    [InlineData("SIGN-IN admin / \"p w\"", "SIGN-IN admin / {{env:VIDYANO_PASSWORD}}")]
+    // Trailing LANGUAGE clause must be preserved.
+    [InlineData("SIGN-IN admin / vidyano LANGUAGE nl-NL", "SIGN-IN admin / {{env:VIDYANO_PASSWORD}} LANGUAGE nl-NL")]
+    // Named session: only the password is touched.
+    [InlineData("SIGN-IN @ops = admin / vidyano", "SIGN-IN @ops = admin / {{env:VIDYANO_PASSWORD}}")]
+    // Secret-named assignment → env ref keyed by the (upper-cased) name.
+    [InlineData("@token = \"abc123\"", "@token = {{env:TOKEN}}")]
+    [InlineData("@apiKey = \"xyz\"", "@apiKey = {{env:APIKEY}}")]
+    public void RedactLine_ReplacesInlineSecrets(string input, string expected)
+    {
+        var (line, changed) = ScriptSecrets.RedactLine(input);
+        Assert.True(changed);
+        Assert.Equal(expected, line);
+    }
+
+    [Theory]
+    [InlineData("SIGN-IN FROM ENV")]                                   // no inline credential
+    [InlineData("SIGN-IN admin / {{env:VIDYANO_PASSWORD}}")]           // already an env reference
+    [InlineData("@region = \"eu-west\"")]                              // not a secret name
+    [InlineData("OPEN MenuItem Home/Customers")]                       // a slash, but not SIGN-IN
+    [InlineData("EXPECT TotalItems = 5")]                              // ordinary assertion
+    public void RedactLine_LeavesNonSecretsUntouched(string input)
+    {
+        var (line, changed) = ScriptSecrets.RedactLine(input);
+        Assert.False(changed);
+        Assert.Equal(input, line);
+    }
+
+    [Fact]
+    public void RedactedSignIn_StaysRunnableViaEnv()
+    {
+        // The redacted line must still be a valid SIGN-IN that resolves its password from the environment —
+        // the whole point is "secure AND runnable", not "broken".
+        var (line, _) = ScriptSecrets.RedactLine("SIGN-IN admin / vidyano");
+        var diags = VidyanoScript.Lint(line);
+        Assert.Empty(diags);
+    }
+}

--- a/Vidyano.Script.Tests/SuiteClassifyTests.cs
+++ b/Vidyano.Script.Tests/SuiteClassifyTests.cs
@@ -1,0 +1,42 @@
+using Vidyano.Script.Diagnostics;
+using Vidyano.Script.Runtime;
+using Xunit;
+using static Vidyano.Script.Tests.SuiteTestData;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>Covers <see cref="SuiteRunner.Classify"/> — the pure map from a finished <see cref="ScriptResult"/>
+/// to a <see cref="FileOutcome"/>. The connection-before-parse ordering and the "skipped only when every
+/// statement skipped" rule are the load-bearing cases.</summary>
+public sealed class SuiteClassifyTests
+{
+    [Fact]
+    public void Passing_IsPassed() =>
+        Assert.Equal(FileOutcome.Passed, SuiteRunner.Classify(Passing()));
+
+    [Fact]
+    public void AssertionFailure_IsFailed() =>
+        Assert.Equal(FileOutcome.Failed, SuiteRunner.Classify(Failing()));
+
+    [Fact]
+    public void EveryStatementSkipped_IsSkipped() =>
+        Assert.Equal(FileOutcome.Skipped, SuiteRunner.Classify(AllSkipped()));
+
+    [Fact]
+    public void ParseDiagnostics_IsParse() =>
+        Assert.Equal(FileOutcome.Parse, SuiteRunner.Classify(ParseError()));
+
+    [Fact]
+    public void NoBaseUri_IsConnection_NotParse() =>
+        // StateNotConnected lands in ParseDiagnostics; it must classify as Connection (exit 3), not Parse (2).
+        Assert.Equal(FileOutcome.Connection, SuiteRunner.Classify(NoUri()));
+
+    [Fact]
+    public void TransportFailure_IsConnection() =>
+        Assert.Equal(FileOutcome.Connection, SuiteRunner.Classify(TransportFailMidRun()));
+
+    [Fact]
+    public void ResolveError_IsFailed_NotConnection() =>
+        // A script that references a missing attribute is a failing test, not an infra problem.
+        Assert.Equal(FileOutcome.Failed, SuiteRunner.Classify(Failing(kind: ErrorKind.ResolveAttribute)));
+}

--- a/Vidyano.Script.Tests/SuiteExitTests.cs
+++ b/Vidyano.Script.Tests/SuiteExitTests.cs
@@ -1,0 +1,65 @@
+using Vidyano.Script.Runtime;
+using Xunit;
+using static Vidyano.Script.Tests.SuiteTestData;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// The exit-code contract is the one thing CI bets the build on, so <see cref="SuiteExit.CodeFor"/> is a pure
+/// function and gets exhaustive coverage here — every outcome and every precedence edge, in memory.
+/// </summary>
+public sealed class SuiteExitTests
+{
+    [Fact]
+    public void AllPassed_Zero() =>
+        Assert.Equal(0, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Passed), File("b", FileOutcome.Passed))));
+
+    [Fact]
+    public void PassedAndSkipped_StillZero() =>
+        Assert.Equal(0, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Passed), File("b", FileOutcome.Skipped))));
+
+    [Fact]
+    public void Empty_Zero() =>
+        Assert.Equal(0, SuiteExit.CodeFor(Suite()));
+
+    [Fact]
+    public void AnyFailed_One() =>
+        Assert.Equal(1, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Passed), File("b", FileOutcome.Failed))));
+
+    [Fact]
+    public void Timeout_FoldsIntoOne_NotThree() =>
+        Assert.Equal(1, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Timeout))));
+
+    [Fact]
+    public void AnyParse_Two() =>
+        Assert.Equal(2, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Passed), File("b", FileOutcome.Parse))));
+
+    [Fact]
+    public void AnyConnection_Three() =>
+        Assert.Equal(3, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Passed), File("b", FileOutcome.Connection))));
+
+    [Fact]
+    public void Connection_Outranks_ParseAndFailed_Three() =>
+        Assert.Equal(3, SuiteExit.CodeFor(Suite(
+            File("a", FileOutcome.Failed),
+            File("b", FileOutcome.Parse),
+            File("c", FileOutcome.Connection))));
+
+    [Fact]
+    public void Parse_Outranks_Failed_Two() =>
+        Assert.Equal(2, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Failed), File("b", FileOutcome.Parse))));
+
+    [Fact]
+    public void FailedOutranksSkipped_One() =>
+        Assert.Equal(1, SuiteExit.CodeFor(Suite(File("a", FileOutcome.Skipped), File("b", FileOutcome.Failed))));
+
+    [Theory]
+    [InlineData(FileOutcome.Passed, true)]
+    [InlineData(FileOutcome.Skipped, true)]
+    [InlineData(FileOutcome.Failed, false)]
+    [InlineData(FileOutcome.Timeout, false)]
+    [InlineData(FileOutcome.Connection, false)]
+    [InlineData(FileOutcome.Parse, false)]
+    public void SuiteOk_TrueOnlyWhenAllPassedOrSkipped(FileOutcome outcome, bool expectedOk) =>
+        Assert.Equal(expectedOk, Suite(File("a", FileOutcome.Passed), File("b", outcome)).Ok);
+}

--- a/Vidyano.Script.Tests/SuiteRunnerTests.cs
+++ b/Vidyano.Script.Tests/SuiteRunnerTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Vidyano.Script.Runtime;
+using Xunit;
+using static Vidyano.Script.Tests.SuiteTestData;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// End-to-end coverage of <see cref="SuiteRunner.RunAsync"/> through its only seam — the per-file executor
+/// delegate. A fabricated executor lets every outcome (pass / fail / skip / timeout / connection) and the
+/// ordering + timeout machinery run with no backend and no disk.
+/// </summary>
+public sealed class SuiteRunnerTests
+{
+    private static IReadOnlyList<ViscSource> Sources(params string[] names) =>
+        names.Select(n => new ViscSource(n, "")).ToList();
+
+    // Executor that maps a source name to a canned result / behaviour.
+    private static async Task<ScriptResult> FakeAsync(ViscSource src, CancellationToken ct)
+    {
+        switch (src.Name)
+        {
+            case "pass.visc": return Passing(src.Name);
+            case "fail.visc": return Failing(src.Name);
+            case "skip.visc": return AllSkipped(src.Name);
+            case "parse.visc": return ParseError(src.Name);
+            case "slow.visc":
+                await Task.Delay(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false); // cancelled by the per-file timeout
+                return Passing(src.Name);
+            case "throw.visc": throw new HttpRequestException("no such host");
+            default: return Passing(src.Name);
+        }
+    }
+
+    [Fact]
+    public async Task ClassifiesEachFile_ByOutcome()
+    {
+        var suite = await SuiteRunner.RunAsync(
+            Sources("pass.visc", "fail.visc", "skip.visc", "parse.visc"), FakeAsync);
+
+        Assert.Equal(FileOutcome.Passed, suite.Files[0].Outcome);
+        Assert.Equal(FileOutcome.Failed, suite.Files[1].Outcome);
+        Assert.Equal(FileOutcome.Skipped, suite.Files[2].Outcome);
+        Assert.Equal(FileOutcome.Parse, suite.Files[3].Outcome);
+        Assert.False(suite.Ok);
+        Assert.Equal(SuiteExit.Parse, SuiteExit.CodeFor(suite)); // parse outranks failed
+    }
+
+    [Fact]
+    public async Task ExecutorThrows_IsConnection_AndCarriesMessage()
+    {
+        var suite = await SuiteRunner.RunAsync(Sources("throw.visc"), FakeAsync);
+
+        Assert.Equal(FileOutcome.Connection, suite.Files[0].Outcome);
+        Assert.Null(suite.Files[0].Script);
+        Assert.Contains("no such host", suite.Files[0].Error);
+        Assert.Equal(SuiteExit.Connection, SuiteExit.CodeFor(suite));
+    }
+
+    [Fact]
+    public async Task PerFileTimeout_FiresTimeout_NotFailure()
+    {
+        var suite = await SuiteRunner.RunAsync(
+            Sources("slow.visc"), FakeAsync,
+            new SuiteRunOptions { PerFileTimeout = TimeSpan.FromMilliseconds(100) });
+
+        Assert.Equal(FileOutcome.Timeout, suite.Files[0].Outcome);
+        Assert.Equal(SuiteExit.Failed, SuiteExit.CodeFor(suite)); // timeout folds into exit 1
+    }
+
+    [Fact]
+    public async Task Timeout_DoesNotKillSiblings()
+    {
+        var suite = await SuiteRunner.RunAsync(
+            Sources("slow.visc", "pass.visc"), FakeAsync,
+            new SuiteRunOptions { MaxParallelism = 2, PerFileTimeout = TimeSpan.FromMilliseconds(100) });
+
+        Assert.Equal(FileOutcome.Timeout, suite.Files[0].Outcome);
+        Assert.Equal(FileOutcome.Passed, suite.Files[1].Outcome);
+    }
+
+    [Fact]
+    public async Task ResultsAreOrderedBySource_RegardlessOfCompletion()
+    {
+        // slow first, fast second — under parallelism the fast one finishes first, but results stay in order.
+        var names = new[] { "slow.visc", "pass.visc", "fail.visc" };
+        var suite = await SuiteRunner.RunAsync(
+            Sources(names), FakeAsync,
+            new SuiteRunOptions { MaxParallelism = 3, PerFileTimeout = TimeSpan.FromMilliseconds(100) });
+
+        Assert.Equal(names, suite.Files.Select(f => f.Source).ToArray());
+    }
+
+    [Fact]
+    public async Task NoTimeout_LetsSlowFilesComplete()
+    {
+        // Without a per-file timeout the "slow" file would hang 30s; assert we don't time it out by default by
+        // using a fast executor only — proving the default is "no limit" (the slow path is covered above).
+        var suite = await SuiteRunner.RunAsync(Sources("pass.visc", "pass.visc"), FakeAsync);
+        Assert.True(suite.Ok);
+        Assert.Equal(SuiteExit.Ok, SuiteExit.CodeFor(suite));
+    }
+}

--- a/Vidyano.Script.Tests/SuiteTestData.cs
+++ b/Vidyano.Script.Tests/SuiteTestData.cs
@@ -1,0 +1,71 @@
+using System;
+using Vidyano.Script.Diagnostics;
+using Vidyano.Script.Parsing;
+using Vidyano.Script.Runtime;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>Fabricates <see cref="ScriptResult"/> / <see cref="FileResult"/> / <see cref="SuiteResult"/> values
+/// from the public result types — no server, no disk — so the suite runner, classifier, exit-code function and
+/// report formatters are all exercisable in memory.</summary>
+internal static class SuiteTestData
+{
+    private static readonly SourceLocation Loc = new("<test>", 1, 1);
+    private static Statement Stmt => new GoBackStmt(Loc);
+
+    public static ScriptResult Passing(string name = "pass.visc")
+    {
+        var st = new StatementResult(Stmt, true, null, Array.Empty<Diagnostic>());
+        var step = new StepResult("ok", Loc, true, new[] { st });
+        return new ScriptResult(name, true, new[] { step }, Array.Empty<Diagnostic>());
+    }
+
+    public static ScriptResult Failing(string name = "fail.visc", string kind = ErrorKind.AssertFailed, string message = "boom")
+    {
+        var d = new Diagnostic(kind, message, Loc);
+        var st = new StatementResult(Stmt, false, null, new[] { d });
+        var step = new StepResult("bad", Loc, false, new[] { st });
+        return new ScriptResult(name, false, new[] { step }, Array.Empty<Diagnostic>());
+    }
+
+    public static ScriptResult AllSkipped(string name = "skip.visc")
+    {
+        var d = new Diagnostic(ErrorKind.StateRequiresUnmet, "skipped", Loc);
+        var st = new StatementResult(Stmt, true, null, new[] { d }, Skipped: true);
+        var step = new StepResult("body", Loc, true, new[] { st }, Skipped: true);
+        return new ScriptResult(name, true, new[] { step }, Array.Empty<Diagnostic>());
+    }
+
+    public static ScriptResult ParseError(string name = "parse.visc")
+    {
+        var d = new Diagnostic(ErrorKind.ParseUnexpectedToken, "unexpected token", Loc);
+        return new ScriptResult(name, false, Array.Empty<StepResult>(), new[] { d });
+    }
+
+    /// <summary>The no-base-URI shape VidyanoScript returns: a parse-only result whose sole diagnostic is
+    /// StateNotConnected — which used to be misclassified as a parse error (exit 2) instead of a connection
+    /// error (exit 3).</summary>
+    public static ScriptResult NoUri(string name = "connect.visc")
+    {
+        var d = new Diagnostic(ErrorKind.StateNotConnected, "no base uri", Loc);
+        return new ScriptResult(name, false, Array.Empty<StepResult>(), new[] { d });
+    }
+
+    public static ScriptResult TransportFailMidRun(string name = "transport.visc")
+    {
+        var d = new Diagnostic(ErrorKind.TransportError, "connection reset", Loc);
+        var st = new StatementResult(Stmt, false, null, new[] { d });
+        var step = new StepResult("signin", Loc, false, new[] { st });
+        return new ScriptResult(name, false, new[] { step }, Array.Empty<Diagnostic>());
+    }
+
+    public static FileResult File(string name, FileOutcome outcome) =>
+        new(name, outcome, null, TimeSpan.Zero);
+
+    /// <summary>Wraps a fabricated <see cref="ScriptResult"/> into a <see cref="FileResult"/> using the real
+    /// classifier, so formatter tests see exactly what production would produce.</summary>
+    public static FileResult FromScript(ScriptResult script) =>
+        new(script.SourcePath, SuiteRunner.Classify(script), script, TimeSpan.Zero);
+
+    public static SuiteResult Suite(params FileResult[] files) => new(files, TimeSpan.Zero);
+}

--- a/Vidyano.Script.Tool/Args.cs
+++ b/Vidyano.Script.Tool/Args.cs
@@ -5,10 +5,17 @@ using Vidyano.Script.Runtime;
 
 namespace Vidyano.Script.Tool;
 
-/// <summary>Parsed CLI options shared by run and repl. Hand-rolled to keep <c>--help</c> honest.</summary>
+/// <summary>One <c>--report &lt;format&gt;[:&lt;target&gt;]</c> request. <see cref="Target"/> is null when the
+/// format was given bare (write to stdout); otherwise it is the file path to write.</summary>
+public readonly record struct ReportSpec(string Format, string? Target);
+
+/// <summary>Parsed CLI options shared by run, test and repl. Hand-rolled to keep <c>--help</c> honest.</summary>
 public sealed class Args
 {
     public string? File { get; set; }
+    /// <summary>All positional arguments, in order. <c>run</c>/<c>lint</c> accept exactly one (they read
+    /// <see cref="File"/> and reject extras); <c>test</c> reads the whole list as files/dirs/globs.</summary>
+    public List<string> Paths { get; } = new();
     public string? AppUri { get; set; }
     public Dictionary<string, object?> Vars { get; } = new(StringComparer.OrdinalIgnoreCase);
     public GuardMode? Mode { get; set; }
@@ -21,7 +28,15 @@ public sealed class Args
     public string? EnvironmentPrefix { get; set; }
     public string? EnvFile { get; set; }
     public Dictionary<string, string?> EnvFileValues { get; } = new(StringComparer.Ordinal);
+    /// <summary><c>--report</c> requests (repeatable). Formats: junit | tap | sarif.</summary>
+    public List<ReportSpec> Reports { get; } = new();
+    /// <summary>Per-file timeout. Null = not set; <see cref="TimeSpan.Zero"/> = explicitly disabled.</summary>
+    public TimeSpan? Timeout { get; set; }
+    /// <summary>Suite parallelism (<c>--jobs</c>). Null = default (serial).</summary>
+    public int? Jobs { get; set; }
     public List<string> Unknown { get; } = new();
+
+    private static readonly string[] ReportFormats = { "junit", "tap", "sarif" };
 
     /// <summary>Parses positional + flag arguments. Unknown flags are collected; callers decide whether to error.</summary>
     public static Args Parse(string[] args)
@@ -93,13 +108,37 @@ public sealed class Args
                     }
                     catch (Exception ex) { result.Unknown.Add($"--env-file '{envPath}' could not be read: {ex.Message}"); }
                     break;
+                case "--report":
+                    if (i + 1 >= args.Length) { result.Unknown.Add("--report requires a format (junit|tap|sarif)[:path]"); break; }
+                    var spec = args[++i];
+                    var colon = spec.IndexOf(':');
+                    var fmt = (colon < 0 ? spec : spec.Substring(0, colon)).ToLowerInvariant();
+                    var target = colon < 0 ? null : spec.Substring(colon + 1);
+                    if (Array.IndexOf(ReportFormats, fmt) < 0)
+                    {
+                        result.Unknown.Add($"--report '{fmt}' is not junit, tap, or sarif");
+                        break;
+                    }
+                    result.Reports.Add(new ReportSpec(fmt, string.IsNullOrEmpty(target) ? null : target));
+                    break;
+                case "--timeout":
+                    if (i + 1 >= args.Length) { result.Unknown.Add("--timeout requires a duration (e.g. 30s, 2m, 0)"); break; }
+                    if (!TryParseDuration(args[++i], out var to)) { result.Unknown.Add($"--timeout '{args[i]}' is not a duration (try 30s, 2m, 1h, or 0)"); break; }
+                    result.Timeout = to; break;
+                case "--jobs":
+                    if (i + 1 >= args.Length) { result.Unknown.Add("--jobs requires a positive integer"); break; }
+                    if (!int.TryParse(args[++i], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var jobs) || jobs < 1)
+                    {
+                        result.Unknown.Add($"--jobs '{args[i]}' is not a positive integer");
+                        break;
+                    }
+                    result.Jobs = jobs; break;
                 case "--json":     result.Json = true; break;
                 case "--verbose":  result.Verbose = true; break;
                 case "--insecure": result.Insecure = true; break;
                 default:
                     if (a.StartsWith('-')) result.Unknown.Add($"Unknown flag: {a}");
-                    else if (result.File is null) result.File = a;
-                    else result.Unknown.Add($"Unexpected positional argument: {a}");
+                    else { result.Paths.Add(a); result.File ??= a; }
                     break;
             }
         }
@@ -128,5 +167,25 @@ public sealed class Args
             opts.EnvLookup = name => envValues.TryGetValue(name, out var v) ? v : Environment.GetEnvironmentVariable(name);
         }
         return opts;
+    }
+
+    /// <summary>Parses a duration: a bare number (seconds) or a number with an <c>s</c>/<c>m</c>/<c>h</c>
+    /// suffix. <c>0</c> yields <see cref="TimeSpan.Zero"/> (the caller treats non-positive as "no limit").</summary>
+    internal static bool TryParseDuration(string text, out TimeSpan value)
+    {
+        value = default;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var unit = char.ToLowerInvariant(text[text.Length - 1]);
+        var hasSuffix = unit is 's' or 'm' or 'h';
+        var number = hasSuffix ? text.Substring(0, text.Length - 1) : text;
+        if (!double.TryParse(number, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var n) || n < 0)
+            return false;
+        value = unit switch
+        {
+            'm' when hasSuffix => TimeSpan.FromMinutes(n),
+            'h' when hasSuffix => TimeSpan.FromHours(n),
+            _ => TimeSpan.FromSeconds(n),
+        };
+        return true;
     }
 }

--- a/Vidyano.Script.Tool/Cli.cs
+++ b/Vidyano.Script.Tool/Cli.cs
@@ -47,6 +47,7 @@ public static class Cli
         return sub switch
         {
             "run"   => await RunCommand.ExecuteAsync(rest).ConfigureAwait(false),
+            "test"  => await TestCommand.ExecuteAsync(rest).ConfigureAwait(false),
             "lint"  => await LintCommand.ExecuteAsync(rest).ConfigureAwait(false),
             "repl"  => await ReplCommand.ExecuteAsync(rest).ConfigureAwait(false),
             // `lsp` speaks LSP over stdio for an editor to drive. It intentionally IGNORES extra args:
@@ -62,7 +63,7 @@ public static class Cli
     private static int UnknownCommand(string sub)
     {
         AnsiConsole.MarkupLine($"[red]Unknown command:[/] [yellow]{Markup.Escape(sub)}[/]");
-        var hint = Diagnostics.Suggester.Hint(sub, new[] { "run", "lint", "repl", "lsp", "help" });
+        var hint = Diagnostics.Suggester.Hint(sub, new[] { "run", "test", "lint", "repl", "lsp", "help" });
         if (hint != null) AnsiConsole.MarkupLine($"[grey]{Markup.Escape(hint)}[/]");
         AnsiConsole.WriteLine();
         PrintUsage();
@@ -87,13 +88,14 @@ public static class Cli
         AnsiConsole.MarkupLine("[bold]vidyano[/] — run .visc scripts against a Vidyano service");
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[bold]Usage:[/]");
-        AnsiConsole.MarkupLine("  vidyano [yellow]run[/]   <file.visc> [grey][[options]][/]   Execute a script.");
+        AnsiConsole.MarkupLine("  vidyano [yellow]run[/]   <file.visc> [grey][[options]][/]   Execute a single script.");
+        AnsiConsole.MarkupLine("  vidyano [yellow]test[/]  <path...> [grey][[options]][/]      Run a suite (files/dirs/globs); aggregate exit code.");
         AnsiConsole.MarkupLine("  vidyano [yellow]lint[/]  <file.visc>                  Parse-check without executing.");
         AnsiConsole.MarkupLine("  vidyano [yellow]repl[/]  [grey][[options]][/]                     Start an interactive .visc REPL.");
         AnsiConsole.MarkupLine("  vidyano [yellow]lsp[/]                            Run the .visc language server over stdio (for editors).");
         AnsiConsole.MarkupLine("  vidyano [yellow]help[/]  [grey][[verbs]][/]                      Show help. 'verbs' lists every .visc verb.");
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold]Options shared by run/repl:[/]");
+        AnsiConsole.MarkupLine("[bold]Options shared by run/test/repl:[/]");
         AnsiConsole.MarkupLine("  [green]--app[/] <uri>            Base URI of the Vidyano service (overrides script's @app).");
         AnsiConsole.MarkupLine("  [green]--var[/] key=value        Pre-seed a script variable. Repeatable.");
         AnsiConsole.MarkupLine("  [green]--mode[/] navigation|audit|direct");
@@ -103,9 +105,15 @@ public static class Cli
         AnsiConsole.MarkupLine("  [green]--now[/] <iso-datetime>   Anchor the run clock for {{@today}}/{{@now}} (then flows by real elapsed).");
         AnsiConsole.MarkupLine("  [green]--env-prefix[/] <prefix>  Bind matching env vars into the variable table, prefix stripped (VIDYANO_REGION -> {{REGION}}). --var wins.");
         AnsiConsole.MarkupLine("  [green]--env-file[/] <path>      Load KEY=VALUE pairs from a .env for {{env:NAME}} / SIGN-IN FROM ENV (shadows the process env). Repeatable; last wins.");
-        AnsiConsole.MarkupLine("  [green]--json[/]                   NDJSON output (one event per line).");
+        AnsiConsole.MarkupLine("  [green]--json[/]                   NDJSON output (one event per line). On lint, emits machine-readable diagnostics.");
         AnsiConsole.MarkupLine("  [green]--verbose[/]                Show per-statement snapshot detail.");
         AnsiConsole.MarkupLine("  [green]--insecure[/]               Bypass TLS validation (local dev certs only).");
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[bold]Options for run/test:[/]");
+        AnsiConsole.MarkupLine("  [green]--timeout[/] <dur>        Per-file timeout: 30s, 2m, 1h, or 0 (off). Default: off.");
+        AnsiConsole.MarkupLine("[bold]Options for test:[/]");
+        AnsiConsole.MarkupLine("  [green]--report[/] <fmt>[grey][[:path]][/]  Emit a report. fmt = junit|tap|sarif. Repeatable; no :path writes to stdout.");
+        AnsiConsole.MarkupLine("  [green]--jobs[/] <n>             Run up to n files concurrently. Default: 1 (serial).");
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[bold]Exit codes:[/]  0 ok, 1 failed, 2 parse error, 3 connection error, 64 usage.");
         AnsiConsole.WriteLine();

--- a/Vidyano.Script.Tool/JsonReporter.cs
+++ b/Vidyano.Script.Tool/JsonReporter.cs
@@ -12,7 +12,7 @@ namespace Vidyano.Script.Tool;
 /// </summary>
 public static class JsonReporter
 {
-    private static readonly JsonSerializerOptions Opts = new()
+    internal static readonly JsonSerializerOptions Opts = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
@@ -53,7 +53,7 @@ public static class JsonReporter
         });
     }
 
-    private static void WriteEvent(object payload)
+    internal static void WriteEvent(object payload)
     {
         Console.Out.WriteLine(JsonSerializer.Serialize(payload, Opts));
     }

--- a/Vidyano.Script.Tool/LintCommand.cs
+++ b/Vidyano.Script.Tool/LintCommand.cs
@@ -34,14 +34,34 @@ public static class LintCommand
             return Task.FromResult(Cli.ExitUsage);
         }
 
+        if (parsed.Paths.Count > 1)
+        {
+            AnsiConsole.MarkupLine("[red]error:[/] [yellow]lint[/] takes a single file.");
+            return Task.FromResult(Cli.ExitUsage);
+        }
+
         var path = parsed.File;
         if (!File.Exists(path))
         {
-            AnsiConsole.MarkupLine($"[red]error:[/] file not found: [yellow]{Markup.Escape(path)}[/]");
+            if (parsed.Json)
+                JsonReporter.WriteEvent(new { type = "lint.summary", sourcePath = path, ok = false, problems = 1, error = "file-not-found" });
+            else
+                AnsiConsole.MarkupLine($"[red]error:[/] file not found: [yellow]{Markup.Escape(path)}[/]");
             return Task.FromResult(Cli.ExitUsage);
         }
 
         var diags = VidyanoScript.Lint(File.ReadAllText(path), path, ExpectedVariables(parsed));
+
+        // --json: machine-readable lint output (one event per diagnostic + a summary). Previously --json was
+        // silently ignored on lint; this honours it so CI can consume lint results without scraping ANSI.
+        if (parsed.Json)
+        {
+            foreach (var d in diags)
+                JsonReporter.WriteEvent(new { type = "lint.diagnostic", diagnostic = d });
+            JsonReporter.WriteEvent(new { type = "lint.summary", sourcePath = path, ok = diags.Count == 0, problems = diags.Count });
+            return Task.FromResult(diags.Count == 0 ? Cli.ExitOk : Cli.ExitLint);
+        }
+
         if (diags.Count == 0)
         {
             AnsiConsole.MarkupLine($"[green]ok[/] {Markup.Escape(path)} (no problems)");

--- a/Vidyano.Script.Tool/ReplCommand.cs
+++ b/Vidyano.Script.Tool/ReplCommand.cs
@@ -151,9 +151,14 @@ public static class ReplCommand
             case ":save":
                 {
                     if (parts.Length < 2) { AnsiConsole.MarkupLine("[red]usage:[/] :save <path> [[--raw]]"); return Task.FromResult(true); }
-                    var saveArgs = parts[1].Trim().Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                    var raw = saveArgs.Contains("--raw");
-                    var path = string.Join(" ", saveArgs.Where(t => t != "--raw"));
+                    // --raw only as a leading or trailing whitespace-delimited token; everything else is the
+                    // path, kept verbatim (paths with spaces — or a "--raw" dir segment — survive intact).
+                    var rest = parts[1].Trim();
+                    var raw = false;
+                    if (rest.Equals("--raw", StringComparison.OrdinalIgnoreCase)) rest = "";
+                    else if (rest.StartsWith("--raw ", StringComparison.OrdinalIgnoreCase)) { raw = true; rest = rest.Substring(6).Trim(); }
+                    else if (rest.EndsWith(" --raw", StringComparison.OrdinalIgnoreCase)) { raw = true; rest = rest.Substring(0, rest.Length - 6).Trim(); }
+                    var path = rest;
                     if (string.IsNullOrEmpty(path)) { AnsiConsole.MarkupLine("[red]usage:[/] :save <path> [[--raw]]"); return Task.FromResult(true); }
 
                     if (raw)

--- a/Vidyano.Script.Tool/ReplCommand.cs
+++ b/Vidyano.Script.Tool/ReplCommand.cs
@@ -113,9 +113,9 @@ public static class ReplCommand
         {
             case ":help":
                 AnsiConsole.MarkupLine("[bold]REPL commands:[/]");
-                AnsiConsole.MarkupLine("  [yellow]:save <path>[/]    Write the session history as a .visc file.");
+                AnsiConsole.MarkupLine("  [yellow]:save <path> [[--raw]][/]  Write history as .visc. Inline credentials are redacted to {{env:…}} unless --raw.");
                 AnsiConsole.MarkupLine("  [yellow]:load <path>[/]    Run a .visc file in this session.");
-                AnsiConsole.MarkupLine("  [yellow]:vars[/]           List current script variables.");
+                AnsiConsole.MarkupLine("  [yellow]:vars[/]           List current script variables (secret-looking values hidden).");
                 AnsiConsole.MarkupLine("  [yellow]:state[/]          Focused view of the current frame (nav, PO/query, actions, details).");
                 AnsiConsole.MarkupLine("  [yellow]:snapshot[/]       Raw JSON of the full session snapshot.");
                 AnsiConsole.MarkupLine("  [yellow]:verbs[/]          List every .visc verb.");
@@ -126,7 +126,14 @@ public static class ReplCommand
                 return Task.FromResult(false);
             case ":vars":
                 foreach (var v in interpreter.Variables.OrderBy(kv => kv.Key))
-                    AnsiConsole.MarkupLine($"  @{Markup.Escape(v.Key)} = {Markup.Escape(v.Value?.ToString() ?? "null")}");
+                {
+                    // Don't echo secret-looking values — a shoulder-surf / screen-share leak. The name is still
+                    // shown so the user knows it's set.
+                    var shown = ScriptSecrets.IsSecretName(v.Key)
+                        ? "[grey]<hidden — secret>[/]"
+                        : Markup.Escape(v.Value?.ToString() ?? "null");
+                    AnsiConsole.MarkupLine($"  @{Markup.Escape(v.Key)} = {shown}");
+                }
                 return Task.FromResult(true);
             case ":state":
                 ConsoleReporter.RenderState(sessions.Current.TakeSnapshot());
@@ -143,9 +150,32 @@ public static class ReplCommand
                 return Task.FromResult(true);
             case ":save":
                 {
-                    if (parts.Length < 2) { AnsiConsole.MarkupLine("[red]usage:[/] :save <path>"); return Task.FromResult(true); }
-                    File.WriteAllLines(parts[1].Trim(), history);
-                    AnsiConsole.MarkupLine($"[green]wrote[/] {Markup.Escape(parts[1].Trim())} ({history.Count} line(s))");
+                    if (parts.Length < 2) { AnsiConsole.MarkupLine("[red]usage:[/] :save <path> [[--raw]]"); return Task.FromResult(true); }
+                    var saveArgs = parts[1].Trim().Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                    var raw = saveArgs.Contains("--raw");
+                    var path = string.Join(" ", saveArgs.Where(t => t != "--raw"));
+                    if (string.IsNullOrEmpty(path)) { AnsiConsole.MarkupLine("[red]usage:[/] :save <path> [[--raw]]"); return Task.FromResult(true); }
+
+                    if (raw)
+                    {
+                        // Explicit opt-in to persist literals as typed (e.g. a throwaway script on a trusted box).
+                        File.WriteAllLines(path, history);
+                        AnsiConsole.MarkupLine($"[yellow]wrote[/] {Markup.Escape(path)} ({history.Count} line(s)) [grey]— verbatim; may contain plaintext secrets[/]");
+                        return Task.FromResult(true);
+                    }
+
+                    var outLines = new List<string>(history.Count);
+                    var changed = 0;
+                    foreach (var l in history)
+                    {
+                        var (redacted, ch) = ScriptSecrets.RedactLine(l);
+                        outLines.Add(redacted);
+                        if (ch) changed++;
+                    }
+                    File.WriteAllLines(path, outLines);
+                    AnsiConsole.MarkupLine($"[green]wrote[/] {Markup.Escape(path)} ({outLines.Count} line(s))");
+                    if (changed > 0)
+                        AnsiConsole.MarkupLine("[grey]redacted " + changed + " inline secret(s) → {{env:…}}; set the env var(s) before running, or re-save with [/][yellow]--raw[/][grey] to keep literals.[/]");
                     return Task.FromResult(true);
                 }
             case ":load":

--- a/Vidyano.Script.Tool/RunCommand.cs
+++ b/Vidyano.Script.Tool/RunCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Spectre.Console;
 using Vidyano.Script;
@@ -26,6 +27,12 @@ public static class RunCommand
         if (a.File is null)
         {
             AnsiConsole.MarkupLine("[red]error:[/] missing <file>. Usage: [yellow]vidyano run <file.visc>[/]");
+            return Cli.ExitUsage;
+        }
+
+        if (a.Paths.Count > 1)
+        {
+            AnsiConsole.MarkupLine("[red]error:[/] [yellow]run[/] takes a single file. Use [yellow]vidyano test <path...>[/] to run a suite.");
             return Cli.ExitUsage;
         }
 
@@ -56,14 +63,33 @@ public static class RunCommand
             }
         }
 
-        var result = await VidyanoScript.RunFileAsync(a.File, options).ConfigureAwait(false);
+        using var cts = new CancellationTokenSource();
+        if (a.Timeout is { } t && t > TimeSpan.Zero) cts.CancelAfter(t);
+
+        ScriptResult result;
+        try
+        {
+            result = await VidyanoScript.RunFileAsync(a.File, options, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            AnsiConsole.MarkupLine($"[red]error:[/] timed out after {a.Timeout!.Value.TotalSeconds:0.#}s");
+            return Cli.ExitFail;
+        }
 
         if (a.Json)
             JsonReporter.Write(result);
         else
             ConsoleReporter.Write(result, a.Verbose);
 
-        if (result.ParseDiagnostics.Count > 0) return Cli.ExitLint;
-        return result.Ok ? Cli.ExitOk : Cli.ExitFail;
+        // Map the result through the same classifier the suite uses, so exit 3 (connection — including the
+        // no-base-URI case that used to surface as parse error 2) is finally returned for `run` too.
+        return SuiteRunner.Classify(result) switch
+        {
+            FileOutcome.Connection => Cli.ExitConnect,
+            FileOutcome.Parse      => Cli.ExitLint,
+            FileOutcome.Failed     => Cli.ExitFail,
+            _                      => Cli.ExitOk,
+        };
     }
 }

--- a/Vidyano.Script.Tool/SourceDiscovery.cs
+++ b/Vidyano.Script.Tool/SourceDiscovery.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Vidyano.Script.Runtime;
 
 namespace Vidyano.Script.Tool;
@@ -36,14 +37,36 @@ internal static class SourceDiscovery
         if (wild < 0)
             return Array.Empty<string>(); // a non-existent literal path — caller reports "no files found"
 
+        // Split the glob at the last separator before the first wildcard: the prefix is a literal root to
+        // walk, the suffix is the match pattern. Walk the root recursively and filter on each file's path
+        // relative to it, so a wildcard in any segment (tests/*/*.visc, tests/**/sub/*.visc) works — we never
+        // hand a separator-bearing pattern to Directory.EnumerateFiles, which throws ArgumentException on one.
         var sep = path.LastIndexOfAny(new[] { '/', '\\' }, wild);
         var root = sep < 0 ? "." : path.Substring(0, sep);
-        var pattern = sep < 0 ? path : path.Substring(sep + 1);
-        var recursive = pattern.Contains("**");
-        var filePattern = pattern.Replace("**/", "").Replace("**\\", "").Replace("**", "");
-        if (filePattern.Length == 0) filePattern = "*.visc";
         if (!Directory.Exists(root)) return Array.Empty<string>();
-        return Directory.EnumerateFiles(root, filePattern,
-            recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+        var pattern = sep < 0 ? path : path.Substring(sep + 1);
+
+        var regex = GlobToRegex(pattern);
+        var rootPrefix = Path.GetFullPath(root).Replace('\\', '/').TrimEnd('/') + "/";
+        return Directory.EnumerateFiles(root, "*.visc", SearchOption.AllDirectories)
+            .Where(f =>
+            {
+                var full = Path.GetFullPath(f).Replace('\\', '/');
+                return full.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase)
+                    && regex.IsMatch(full.Substring(rootPrefix.Length));
+            });
+    }
+
+    // Compiles a glob pattern (already split off its literal root) to an anchored regex over the
+    // forward-slash relative path. `**/` spans any number of directories (including none), `**` spans
+    // anything, `*` stays within one segment, `?` matches one non-separator char.
+    private static Regex GlobToRegex(string glob)
+    {
+        var body = Regex.Escape(glob.Replace('\\', '/'))
+            .Replace(@"\*\*/", "(?:.*/)?")
+            .Replace(@"\*\*", ".*")
+            .Replace(@"\*", "[^/]*")
+            .Replace(@"\?", "[^/]");
+        return new Regex("^" + body + "$", RegexOptions.IgnoreCase);
     }
 }

--- a/Vidyano.Script.Tool/SourceDiscovery.cs
+++ b/Vidyano.Script.Tool/SourceDiscovery.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Vidyano.Script.Runtime;
+
+namespace Vidyano.Script.Tool;
+
+/// <summary>Turns CLI path arguments into the <see cref="ViscSource"/> set a suite runs. Each argument may be
+/// a directory (recursive <c>*.visc</c>), an explicit file, or a glob (<c>tests/**/*.visc</c>, <c>*.visc</c>).
+/// Results are de-duplicated and ordered so a suite run — and its reports — are deterministic.</summary>
+internal static class SourceDiscovery
+{
+    public static IReadOnlyList<ViscSource> Discover(IEnumerable<string> paths)
+    {
+        // Key dedup/ordering on the full path (two args can resolve to the same file); display with forward
+        // slashes so report identifiers (JUnit classname, SARIF uri) are stable across OSes.
+        var seen = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in paths)
+            foreach (var file in Expand(p))
+            {
+                var full = Path.GetFullPath(file);
+                if (!seen.ContainsKey(full)) seen[full] = file.Replace('\\', '/');
+            }
+        return seen.Values.Select(display => new ViscSource(display, File.ReadAllText(display))).ToList();
+    }
+
+    private static IEnumerable<string> Expand(string path)
+    {
+        if (Directory.Exists(path))
+            return Directory.EnumerateFiles(path, "*.visc", SearchOption.AllDirectories);
+        if (File.Exists(path))
+            return new[] { path };
+
+        var wild = path.IndexOfAny(new[] { '*', '?' });
+        if (wild < 0)
+            return Array.Empty<string>(); // a non-existent literal path — caller reports "no files found"
+
+        var sep = path.LastIndexOfAny(new[] { '/', '\\' }, wild);
+        var root = sep < 0 ? "." : path.Substring(0, sep);
+        var pattern = sep < 0 ? path : path.Substring(sep + 1);
+        var recursive = pattern.Contains("**");
+        var filePattern = pattern.Replace("**/", "").Replace("**\\", "").Replace("**", "");
+        if (filePattern.Length == 0) filePattern = "*.visc";
+        if (!Directory.Exists(root)) return Array.Empty<string>();
+        return Directory.EnumerateFiles(root, filePattern,
+            recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+    }
+}

--- a/Vidyano.Script.Tool/SuiteConsoleReporter.cs
+++ b/Vidyano.Script.Tool/SuiteConsoleReporter.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console;
+using Vidyano.Script.Runtime;
+
+namespace Vidyano.Script.Tool;
+
+/// <summary>Human-readable suite output: one line per file with its outcome and duration, the failing
+/// diagnostics expanded beneath failures, then a tally. The single-file counterpart is
+/// <see cref="ConsoleReporter"/>; this is what <c>vidyano test</c> prints when not in <c>--json</c> mode.</summary>
+public static class SuiteConsoleReporter
+{
+    public static void Write(SuiteResult suite, bool verbose)
+    {
+        foreach (var file in suite.Files)
+        {
+            var (glyph, color) = Glyph(file.Outcome);
+            var ms = (long)file.Duration.TotalMilliseconds;
+            AnsiConsole.MarkupLine($"  [{color}]{glyph}[/] {Markup.Escape(file.Source)} [grey]({ms} ms{Tag(file.Outcome)})[/]");
+
+            if (file.Outcome is FileOutcome.Passed or FileOutcome.Skipped)
+                continue;
+
+            // Surface why it isn't green: the failing statements' diagnostics, or the file-level error.
+            var diags = file.Script is { } s
+                ? s.ParseDiagnostics.Concat(s.Steps.SelectMany(st => st.Statements)
+                    .Where(x => !x.Ok && !x.Skipped).SelectMany(x => x.Diagnostics)).ToList()
+                : new List<Vidyano.Script.Diagnostics.Diagnostic>();
+            if (diags.Count > 0)
+                foreach (var d in diags)
+                    ConsoleReporter.WriteDiagnostic(d, indent: "    ");
+            else if (!string.IsNullOrEmpty(file.Error))
+                AnsiConsole.MarkupLine($"    [grey]{Markup.Escape(file.Error!)}[/]");
+        }
+
+        AnsiConsole.WriteLine();
+        var counts = suite.Files.GroupBy(f => f.Outcome).ToDictionary(g => g.Key, g => g.Count());
+        int N(FileOutcome o) => counts.TryGetValue(o, out var c) ? c : 0;
+        var passed = N(FileOutcome.Passed);
+        var parts = new List<string> { $"[bold]{passed}[/]/{suite.Files.Count} ok" };
+        if (N(FileOutcome.Failed) > 0)     parts.Add($"[red]{N(FileOutcome.Failed)} failed[/]");
+        if (N(FileOutcome.Timeout) > 0)    parts.Add($"[red]{N(FileOutcome.Timeout)} timed out[/]");
+        if (N(FileOutcome.Connection) > 0) parts.Add($"[red]{N(FileOutcome.Connection)} connection[/]");
+        if (N(FileOutcome.Parse) > 0)      parts.Add($"[red]{N(FileOutcome.Parse)} parse[/]");
+        if (N(FileOutcome.Skipped) > 0)    parts.Add($"[yellow]{N(FileOutcome.Skipped)} skipped[/]");
+        AnsiConsole.MarkupLine($"{string.Join(", ", parts)}  [grey]({(long)suite.Duration.TotalMilliseconds} ms)[/]");
+    }
+
+    private static (string Glyph, string Color) Glyph(FileOutcome o) => o switch
+    {
+        FileOutcome.Passed  => ("✓", "green"),
+        FileOutcome.Skipped => ("↓", "yellow"),
+        _                   => ("✗", "red"),
+    };
+
+    private static string Tag(FileOutcome o) => o switch
+    {
+        FileOutcome.Timeout    => ", timeout",
+        FileOutcome.Connection => ", connection",
+        FileOutcome.Parse      => ", parse",
+        _                      => "",
+    };
+}

--- a/Vidyano.Script.Tool/SuiteJsonReporter.cs
+++ b/Vidyano.Script.Tool/SuiteJsonReporter.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using Vidyano.Script.Runtime;
+
+namespace Vidyano.Script.Tool;
+
+/// <summary>
+/// NDJSON suite output: a <c>file.start</c> / (the existing single-file <c>step.*</c>/<c>statement.*</c>
+/// events from <see cref="JsonReporter"/>) / <c>file.end</c> frame per file, then a final <c>suite.summary</c>.
+/// Wrapping the documented per-file schema rather than replacing it keeps existing single-file consumers
+/// working while adding the suite envelope.
+/// </summary>
+public static class SuiteJsonReporter
+{
+    public static void Write(SuiteResult suite)
+    {
+        foreach (var file in suite.Files)
+        {
+            JsonReporter.WriteEvent(new { type = "file.start", source = file.Source });
+            if (file.Script is { } script)
+                JsonReporter.Write(script);                       // the documented per-file event stream
+            else
+                JsonReporter.WriteEvent(new { type = "file.error", source = file.Source, error = file.Error });
+            JsonReporter.WriteEvent(new
+            {
+                type = "file.end",
+                source = file.Source,
+                outcome = file.Outcome.ToString(),
+                durationMs = (long)file.Duration.TotalMilliseconds,
+            });
+        }
+
+        int Count(FileOutcome o) => suite.Files.Count(f => f.Outcome == o);
+        JsonReporter.WriteEvent(new
+        {
+            type = "suite.summary",
+            files = suite.Files.Count,
+            passed = Count(FileOutcome.Passed),
+            failed = Count(FileOutcome.Failed),
+            skipped = Count(FileOutcome.Skipped),
+            timeout = Count(FileOutcome.Timeout),
+            connection = Count(FileOutcome.Connection),
+            parse = Count(FileOutcome.Parse),
+            ok = suite.Ok,
+            exitCode = SuiteExit.CodeFor(suite),
+            durationMs = (long)suite.Duration.TotalMilliseconds,
+        });
+    }
+}

--- a/Vidyano.Script.Tool/TestCommand.cs
+++ b/Vidyano.Script.Tool/TestCommand.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Spectre.Console;
+using Vidyano.Script;
+using Vidyano.Script.Runtime;
+using Vidyano.Script.Runtime.Reporting;
+
+namespace Vidyano.Script.Tool;
+
+/// <summary><c>vidyano test &lt;path...&gt;</c> — discover and run a suite of .visc files, render the result,
+/// optionally emit JUnit/TAP/SARIF reports, and return an aggregate exit code.</summary>
+public static class TestCommand
+{
+    public static async Task<int> ExecuteAsync(string[] args)
+    {
+        var a = Args.Parse(args);
+
+        if (a.Unknown.Count > 0)
+        {
+            foreach (var u in a.Unknown) AnsiConsole.MarkupLine($"[red]error:[/] {Markup.Escape(u)}");
+            AnsiConsole.MarkupLine("Run [yellow]vidyano help[/] for usage.");
+            return Cli.ExitUsage;
+        }
+
+        if (a.Paths.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[red]error:[/] missing <path>. Usage: [yellow]vidyano test <file|dir|glob>...[/]");
+            return Cli.ExitUsage;
+        }
+
+        // Build a template options once (including loading any --tools packs); each file gets a fresh copy so
+        // concurrent runs never share the variable/tool tables.
+        var template = a.ToOptions();
+        if (a.ToolPaths.Count > 0)
+        {
+            try { ToolPackLoader.LoadInto(a.ToolPaths, template); }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]error:[/] {Markup.Escape(ex.Message)}");
+                return Cli.ExitUsage;
+            }
+        }
+
+        var sources = SourceDiscovery.Discover(a.Paths);
+        if (sources.Count == 0)
+        {
+            // A passing run of zero tests is the classic CI lie — fail loudly instead.
+            AnsiConsole.MarkupLine($"[red]error:[/] no .visc files found in: [yellow]{Markup.Escape(string.Join(", ", a.Paths))}[/]");
+            return Cli.ExitUsage;
+        }
+
+        var runOptions = new SuiteRunOptions
+        {
+            MaxParallelism = a.Jobs ?? 1,
+            PerFileTimeout = a.Timeout,
+        };
+
+        var suite = await VidyanoScript.RunSuiteAsync(
+            sources,
+            _ => new VidyanoScriptOptions(template),
+            runOptions).ConfigureAwait(false);
+
+        if (a.Json)
+            SuiteJsonReporter.Write(suite);
+        else
+            SuiteConsoleReporter.Write(suite, a.Verbose);
+
+        foreach (var report in a.Reports)
+            EmitReport(report, suite, a.Json);
+
+        return SuiteExit.CodeFor(suite);
+    }
+
+    private static void EmitReport(ReportSpec report, SuiteResult suite, bool json)
+    {
+        IReportFormatter formatter = report.Format switch
+        {
+            "junit" => new JUnitFormatter(),
+            "tap"   => new TapFormatter(),
+            "sarif" => new SarifFormatter(),
+            _       => new JUnitFormatter(), // unreachable: Args validated the format
+        };
+
+        var artifact = formatter.Render(suite);
+        if (report.Target is { } path)
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            File.WriteAllText(path, artifact.Text);
+            if (!json) AnsiConsole.MarkupLine($"[grey]wrote {report.Format} report → {Markup.Escape(path)}[/]");
+        }
+        else
+        {
+            // No target: write to stdout (a report piped straight to another tool).
+            Console.Out.Write(artifact.Text);
+            if (artifact.Text.Length > 0 && artifact.Text[artifact.Text.Length - 1] != '\n')
+                Console.Out.WriteLine();
+        }
+    }
+}

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -105,22 +105,26 @@ public sealed class Interpreter
 
         var steps = new List<StepResult>();
         var anyFail = false;
+        var runStart = Stopwatch.GetTimestamp();
         foreach (var step in script.Steps)
         {
             var (stepRes, ok) = await RunStepAsync(step).ConfigureAwait(false);
             steps.Add(stepRes);
             if (!ok) anyFail = true;
         }
-        return new ScriptResult(script.Location.SourcePath, !anyFail, steps, Array.Empty<Diagnostic>());
+        return new ScriptResult(script.Location.SourcePath, !anyFail, steps, Array.Empty<Diagnostic>(),
+            Stopwatch.GetElapsedTime(runStart));
     }
 
     private async Task<(StepResult Result, bool Ok)> RunStepAsync(Step step)
     {
         var stmtResults = new List<StatementResult>(step.Statements.Count);
+        var stepStart = Stopwatch.GetTimestamp();
         await RunStatementsAsync(step.Statements, stmtResults).ConfigureAwait(false);
+        var elapsed = Stopwatch.GetElapsedTime(stepStart);
         var anyFail = stmtResults.Any(s => !s.Ok);
         var skipped = stmtResults.Count > 0 && stmtResults.All(s => s.Skipped);
-        return (new StepResult(step.Label, step.Location, !anyFail, stmtResults, skipped), !anyFail);
+        return (new StepResult(step.Label, step.Location, !anyFail, stmtResults, skipped, elapsed), !anyFail);
     }
 
     /// <summary>Runs a statement sequence (a step's body, or a loop's body for one iteration), appending one

--- a/Vidyano.Script/Runtime/Reporting/IReportFormatter.cs
+++ b/Vidyano.Script/Runtime/Reporting/IReportFormatter.cs
@@ -1,0 +1,20 @@
+namespace Vidyano.Script.Runtime.Reporting;
+
+/// <summary>A rendered report: the <paramref name="Format"/> that produced it, the full <paramref name="Text"/>
+/// (the host writes it to a file or stdout — the formatter never touches I/O), and a
+/// <paramref name="SuggestedFileName"/> for when the caller asks for a report without naming a target.</summary>
+public readonly record struct ReportArtifact(string Format, string Text, string SuggestedFileName);
+
+/// <summary>
+/// Turns a finished <see cref="SuiteResult"/> into a machine-readable report. Implementations are pure —
+/// no clock, no file system, output a deterministic function of the input — so the exact bytes are
+/// assertable in a test. Adding a format is adding an implementation; nothing else changes (the closed
+/// built-in set is junit / tap / sarif, kept internal-extensible rather than a public plugin surface).
+/// </summary>
+public interface IReportFormatter
+{
+    /// <summary>Stable lowercase format token, as named on the CLI (<c>--report junit</c>).</summary>
+    string Format { get; }
+
+    ReportArtifact Render(SuiteResult suite);
+}

--- a/Vidyano.Script/Runtime/Reporting/JUnitFormatter.cs
+++ b/Vidyano.Script/Runtime/Reporting/JUnitFormatter.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Vidyano.Script.Diagnostics;
+
+namespace Vidyano.Script.Runtime.Reporting;
+
+/// <summary>
+/// Renders a suite as JUnit XML — the format CI dashboards (GitLab, Jenkins, GitHub test-reporter) read.
+/// Each file becomes a <c>&lt;testsuite&gt;</c>; each <c>###</c> step becomes a <c>&lt;testcase&gt;</c>. Files
+/// that never ran (parse / connection / timeout) contribute a single synthetic <c>&lt;testcase&gt;</c> carrying
+/// an <c>&lt;error&gt;</c>. Output is deterministic (no timestamps, no hostname, invariant durations, LF
+/// line endings) so it is byte-assertable in a test.
+/// </summary>
+public sealed class JUnitFormatter : IReportFormatter
+{
+    public string Format => "junit";
+
+    private enum Kind { Pass, Skipped, Failure, Error }
+
+    private readonly record struct Case(string Name, TimeSpan Time, Kind Kind, string? Message, string? Type, string? Detail);
+
+    public ReportArtifact Render(SuiteResult suite)
+    {
+        int tests = 0, failures = 0, errors = 0, skipped = 0;
+        var suiteEls = new List<XElement>(suite.Files.Count);
+
+        foreach (var file in suite.Files)
+        {
+            var cases = BuildCases(file).ToList();
+            int f = cases.Count(c => c.Kind == Kind.Failure);
+            int e = cases.Count(c => c.Kind == Kind.Error);
+            int s = cases.Count(c => c.Kind == Kind.Skipped);
+            tests += cases.Count; failures += f; errors += e; skipped += s;
+
+            suiteEls.Add(new XElement("testsuite",
+                new XAttribute("name", file.Source),
+                new XAttribute("tests", cases.Count),
+                new XAttribute("failures", f),
+                new XAttribute("errors", e),
+                new XAttribute("skipped", s),
+                new XAttribute("time", ReportHelpers.Seconds(file.Duration)),
+                cases.Select(c => ToElement(c, file.Source))));
+        }
+
+        var root = new XElement("testsuites",
+            new XAttribute("name", "vidyano"),
+            new XAttribute("tests", tests),
+            new XAttribute("failures", failures),
+            new XAttribute("errors", errors),
+            new XAttribute("skipped", skipped),
+            new XAttribute("time", ReportHelpers.Seconds(suite.Duration)),
+            suiteEls);
+
+        return new ReportArtifact(Format, Serialize(root), "vidyano.junit.xml");
+    }
+
+    private static XElement ToElement(Case c, string classname)
+    {
+        var tc = new XElement("testcase",
+            new XAttribute("name", c.Name),
+            new XAttribute("classname", classname),
+            new XAttribute("time", ReportHelpers.Seconds(c.Time)));
+        switch (c.Kind)
+        {
+            case Kind.Failure:
+                tc.Add(new XElement("failure",
+                    new XAttribute("message", c.Message ?? ""),
+                    new XAttribute("type", c.Type ?? ErrorKind.AssertFailed),
+                    c.Detail ?? ""));
+                break;
+            case Kind.Error:
+                tc.Add(new XElement("error",
+                    new XAttribute("message", c.Message ?? ""),
+                    new XAttribute("type", c.Type ?? ErrorKind.TransportError),
+                    c.Detail ?? ""));
+                break;
+            case Kind.Skipped:
+                tc.Add(new XElement("skipped"));
+                break;
+        }
+        return tc;
+    }
+
+    private static IEnumerable<Case> BuildCases(FileResult file)
+    {
+        if (file.Script is { Steps.Count: > 0 } script)
+        {
+            foreach (var step in script.Steps)
+            {
+                var name = string.IsNullOrEmpty(step.Label) ? "(step)" : step.Label;
+                if (step.Skipped)
+                {
+                    yield return new Case(name, step.Duration, Kind.Skipped, null, null, null);
+                }
+                else if (step.Ok)
+                {
+                    yield return new Case(name, step.Duration, Kind.Pass, null, null, null);
+                }
+                else
+                {
+                    var diags = step.Statements.Where(s => !s.Ok && !s.Skipped).SelectMany(s => s.Diagnostics).ToList();
+                    var first = diags.FirstOrDefault();
+                    var kind = ReportHelpers.IsAssertish(first?.Kind) ? Kind.Failure : Kind.Error;
+                    yield return new Case(name, step.Duration, kind,
+                        first?.Message ?? "step failed", first?.Kind,
+                        string.Join("\n", diags.Select(ReportHelpers.OneLine)));
+                }
+            }
+            yield break;
+        }
+
+        // No steps (parse error) or no result at all (timeout / connection): one synthetic case for the file.
+        var fd = ReportHelpers.FailureDiagnostics(file.Script ?? Empty).ToList();
+        var head = fd.FirstOrDefault();
+        var message = file.Error ?? head?.Message ?? file.Outcome.ToString();
+        var detail = fd.Count > 0 ? string.Join("\n", fd.Select(ReportHelpers.OneLine)) : file.Error;
+        yield return new Case(file.Source, file.Duration, Kind.Error, message, head?.Kind, detail);
+    }
+
+    private static readonly ScriptResult Empty =
+        new("", false, Array.Empty<StepResult>(), Array.Empty<Diagnostic>());
+
+    private static string Serialize(XElement root)
+    {
+        var settings = new XmlWriterSettings
+        {
+            Indent = true,
+            IndentChars = "  ",
+            NewLineChars = "\n",
+            OmitXmlDeclaration = false,
+            Encoding = System.Text.Encoding.UTF8,
+        };
+        using var sw = new ReportHelpers.Utf8StringWriter();
+        using (var xw = XmlWriter.Create(sw, settings))
+            new XDocument(root).Save(xw);
+        return sw.ToString();
+    }
+}

--- a/Vidyano.Script/Runtime/Reporting/ReportHelpers.cs
+++ b/Vidyano.Script/Runtime/Reporting/ReportHelpers.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Vidyano.Script.Diagnostics;
+
+namespace Vidyano.Script.Runtime.Reporting;
+
+/// <summary>Shared, side-effect-free helpers for the report formatters. Kept here so JUnit / TAP / SARIF
+/// agree on what counts as an assertion failure vs an error and how durations are rendered.</summary>
+internal static class ReportHelpers
+{
+    /// <summary>A failure that maps to a JUnit <c>&lt;failure&gt;</c> (the test ran and an expectation didn't
+    /// hold) rather than an <c>&lt;error&gt;</c> (it couldn't run / blew up). Assertions and UI guards are
+    /// failures; parse / resolve / state / transport problems are errors.</summary>
+    public static bool IsAssertish(string? kind) =>
+        kind is not null && (kind.StartsWith("assert-", StringComparison.Ordinal)
+                          || kind.StartsWith("guard-", StringComparison.Ordinal));
+
+    /// <summary>Every diagnostic that explains why a file is not green: parse diagnostics plus the diagnostics
+    /// of failing (non-skipped) statements, in document order.</summary>
+    public static IEnumerable<Diagnostic> FailureDiagnostics(ScriptResult r) =>
+        r.ParseDiagnostics.Concat(
+            r.Steps.SelectMany(s => s.Statements).Where(s => !s.Ok && !s.Skipped).SelectMany(s => s.Diagnostics));
+
+    public static string Seconds(TimeSpan t) =>
+        t.TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture);
+
+    public static string OneLine(Diagnostic d) =>
+        $"[{d.Kind}] {d.Location.Line}:{d.Location.Column} {d.Message}"
+        + (string.IsNullOrEmpty(d.Hint) ? "" : $"  hint: {d.Hint}");
+
+    /// <summary>A <see cref="StringWriter"/> that reports UTF-8 so an <see cref="System.Xml.XmlWriter"/>
+    /// emits <c>encoding="utf-8"</c> in the declaration while still building an in-memory string.</summary>
+    public sealed class Utf8StringWriter : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+    }
+}

--- a/Vidyano.Script/Runtime/Reporting/SarifFormatter.cs
+++ b/Vidyano.Script/Runtime/Reporting/SarifFormatter.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Vidyano.Script.Diagnostics;
+
+namespace Vidyano.Script.Runtime.Reporting;
+
+/// <summary>
+/// Renders a suite as SARIF 2.1.0 — the format GitHub code scanning and other static-analysis surfaces read.
+/// Every failure diagnostic (parse errors and failing-statement diagnostics, across all files) becomes a
+/// <c>result</c> with its <see cref="ErrorKind"/> as the rule id and a physical location (file + line). Output
+/// is deterministic (property order fixed, LF endings) so it is byte-assertable.
+/// </summary>
+public sealed class SarifFormatter : IReportFormatter
+{
+    public string Format => "sarif";
+
+    public ReportArtifact Render(SuiteResult suite)
+    {
+        var results = new List<object>();
+        var ruleIds = new SortedSet<string>(System.StringComparer.Ordinal);
+
+        foreach (var file in suite.Files)
+        {
+            if (file.Script is not { } script)
+            {
+                // No result at all (timeout / connection thrown before a ScriptResult): one synthetic result.
+                var kind = file.Outcome == FileOutcome.Timeout ? "state-timeout" : ErrorKind.TransportError;
+                ruleIds.Add(kind);
+                results.Add(Result(kind, file.Error ?? file.Outcome.ToString(), file.Source, 0));
+                continue;
+            }
+
+            foreach (var d in ReportHelpers.FailureDiagnostics(script))
+            {
+                ruleIds.Add(d.Kind);
+                results.Add(Result(d.Kind, d.Message, file.Source, d.Location.Line));
+            }
+        }
+
+        var sarif = new
+        {
+            version = "2.1.0",
+            schema = "https://json.schemastore.org/sarif-2.1.0.json",
+            runs = new[]
+            {
+                new
+                {
+                    tool = new
+                    {
+                        driver = new
+                        {
+                            name = "vidyano",
+                            rules = ruleIds.Select(id => new { id }).ToArray(),
+                        },
+                    },
+                    results = results.ToArray(),
+                },
+            },
+        };
+
+        var json = JsonSerializer.Serialize(sarif, JsonOpts).Replace("\r\n", "\n");
+        // System.Text.Json can't emit a "$schema" property name from a C# identifier, so patch the
+        // placeholder key the anonymous type used. Done as a string fix to keep the model a plain literal.
+        json = json.Replace("\"schema\":", "\"$schema\":");
+        return new ReportArtifact(Format, json, "vidyano.sarif");
+    }
+
+    private static object Result(string ruleId, string message, string uri, int line) => new
+    {
+        ruleId,
+        level = "error",
+        message = new { text = message },
+        locations = new[]
+        {
+            new
+            {
+                physicalLocation = new
+                {
+                    artifactLocation = new { uri },
+                    region = new { startLine = line > 0 ? line : 1 },
+                },
+            },
+        },
+    };
+
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true };
+}

--- a/Vidyano.Script/Runtime/Reporting/SarifFormatter.cs
+++ b/Vidyano.Script/Runtime/Reporting/SarifFormatter.cs
@@ -38,11 +38,14 @@ public sealed class SarifFormatter : IReportFormatter
             }
         }
 
-        var sarif = new
+        // A dictionary root lets us emit the literal "$schema" key (System.Text.Json can't project it from a
+        // C# identifier) without string-patching the serialized JSON — patching could corrupt a diagnostic
+        // message that happened to contain the substring "schema":. Insertion order is the emit order.
+        var sarif = new Dictionary<string, object>
         {
-            version = "2.1.0",
-            schema = "https://json.schemastore.org/sarif-2.1.0.json",
-            runs = new[]
+            ["version"] = "2.1.0",
+            ["$schema"] = "https://json.schemastore.org/sarif-2.1.0.json",
+            ["runs"] = new[]
             {
                 new
                 {
@@ -60,9 +63,6 @@ public sealed class SarifFormatter : IReportFormatter
         };
 
         var json = JsonSerializer.Serialize(sarif, JsonOpts).Replace("\r\n", "\n");
-        // System.Text.Json can't emit a "$schema" property name from a C# identifier, so patch the
-        // placeholder key the anonymous type used. Done as a string fix to keep the model a plain literal.
-        json = json.Replace("\"schema\":", "\"$schema\":");
         return new ReportArtifact(Format, json, "vidyano.sarif");
     }
 

--- a/Vidyano.Script/Runtime/Reporting/TapFormatter.cs
+++ b/Vidyano.Script/Runtime/Reporting/TapFormatter.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using System.Text;
+
+namespace Vidyano.Script.Runtime.Reporting;
+
+/// <summary>
+/// Renders a suite as TAP version 13 — one test point per file. Passed / Skipped files are <c>ok</c>
+/// (skips carry a <c># SKIP</c> directive); everything else is <c>not ok</c> with a YAML diagnostic block.
+/// Flat by design: TAP has no nesting, and per-file granularity is what TAP consumers expect. LF endings,
+/// no timestamps — deterministic.
+/// </summary>
+public sealed class TapFormatter : IReportFormatter
+{
+    public string Format => "tap";
+
+    public ReportArtifact Render(SuiteResult suite)
+    {
+        var sb = new StringBuilder();
+        sb.Append("TAP version 13\n");
+        sb.Append("1..").Append(suite.Files.Count).Append('\n');
+
+        var n = 0;
+        foreach (var file in suite.Files)
+        {
+            n++;
+            var ok = file.Outcome is FileOutcome.Passed or FileOutcome.Skipped;
+            sb.Append(ok ? "ok " : "not ok ").Append(n).Append(" - ").Append(file.Source);
+            if (file.Outcome == FileOutcome.Skipped)
+                sb.Append(" # SKIP all statements skipped");
+            sb.Append('\n');
+
+            if (!ok)
+            {
+                var message = FirstMessage(file);
+                sb.Append("  ---\n");
+                sb.Append("  message: ").Append(YamlScalar(message)).Append('\n');
+                sb.Append("  severity: ").Append(file.Outcome.ToString().ToLowerInvariant()).Append('\n');
+                sb.Append("  ...\n");
+            }
+        }
+
+        return new ReportArtifact(Format, sb.ToString(), "vidyano.tap");
+    }
+
+    private static string FirstMessage(FileResult file)
+    {
+        if (file.Error is { Length: > 0 } err) return err;
+        if (file.Script is { } script)
+        {
+            var d = ReportHelpers.FailureDiagnostics(script).FirstOrDefault();
+            if (d is not null) return d.Message;
+        }
+        return file.Outcome.ToString();
+    }
+
+    // Single-line, double-quoted YAML scalar: escape backslash and quote so a message with a colon or
+    // quote stays valid YAML on one line.
+    private static string YamlScalar(string s) =>
+        "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", " ").Replace("\r", "") + "\"";
+}

--- a/Vidyano.Script/Runtime/ScriptSecrets.cs
+++ b/Vidyano.Script/Runtime/ScriptSecrets.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Vidyano.Script.Parsing;
+
+namespace Vidyano.Script.Runtime;
+
+/// <summary>
+/// Keeps plaintext credentials out of persisted .visc and out of aggregated variable dumps. A REPL session
+/// where you type <c>SIGN-IN admin / hunter2</c> would otherwise write that password verbatim when you
+/// <c>:save</c> the history, and <c>:vars</c> would echo any secret-looking variable. This redacts an inline
+/// SIGN-IN password (and secret-named literal assignments) to an <c>{{env:…}}</c> reference — keeping the saved
+/// script runnable the blessed way (supply the secret via the environment) instead of baking it into a file
+/// that might be committed.
+/// </summary>
+public static class ScriptSecrets
+{
+    // Substring match on a variable/credential name. Deliberately broad: a false positive only hides a value
+    // from a dump or routes it through env on save — both safe — while a miss could leak a real secret.
+    private static readonly Regex SecretName = new(
+        @"(password|passwd|pwd|secret|token|api[_-]?key|apikey|credential|auth)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>The default environment variable an inline SIGN-IN password is redirected to — the same name
+    /// <c>SIGN-IN FROM ENV</c> reads, so a redacted script runs with the same setup.</summary>
+    public const string SignInPasswordEnv = "VIDYANO_PASSWORD";
+
+    /// <summary>True when a variable/credential name looks secret and its value should be hidden from dumps and
+    /// kept out of saved scripts.</summary>
+    public static bool IsSecretName(string? name) => !string.IsNullOrEmpty(name) && SecretName.IsMatch(name!);
+
+    /// <summary>
+    /// Returns <paramref name="line"/> with any inline secret replaced by an <c>{{env:…}}</c> reference, and
+    /// whether anything changed. Two shapes are redacted: a <c>SIGN-IN … / &lt;literal&gt;</c> password becomes
+    /// <c>{{env:VIDYANO_PASSWORD}}</c>, and a <c>@&lt;secret-name&gt; = &lt;literal&gt;</c> assignment becomes
+    /// <c>{{env:&lt;NAME&gt;}}</c>. A password/value that is already an interpolation (<c>{{…}}</c>) or
+    /// <c>SIGN-IN FROM ENV</c> is left untouched. Other lines pass through unchanged.
+    /// </summary>
+    public static (string Line, bool Changed) RedactLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return (line, false);
+
+        var tokens = new Lexer(line, "<redact>").Tokenize();
+        if (tokens.Count == 0) return (line, false);
+
+        // SIGN-IN … / <inline password> — replace the password token (everything from its start column up to
+        // the next token, e.g. a trailing LANGUAGE clause, or end of line).
+        if (tokens[0].Kind == TokenKind.Identifier &&
+            string.Equals(tokens[0].Lexeme, "SIGN-IN", StringComparison.OrdinalIgnoreCase))
+        {
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                if (tokens[i].Kind != TokenKind.Slash) continue;
+                if (i + 1 < tokens.Count && IsInlineLiteral(tokens[i + 1].Kind))
+                    return (ReplaceTokenSpan(line, tokens, i + 1, $"{{{{env:{SignInPasswordEnv}}}}}"), true);
+                break; // a Slash with no literal after it (e.g. {{env:…}}) — nothing to redact
+            }
+            return (line, false);
+        }
+
+        // @<secret-name> = <inline literal>  →  @<secret-name> = {{env:<NAME>}}
+        if (tokens.Count >= 3 && tokens[0].Kind == TokenKind.At && IsSecretName(tokens[0].Lexeme) &&
+            tokens[1].Kind == TokenKind.Equals && IsInlineLiteral(tokens[2].Kind))
+        {
+            return (ReplaceTokenSpan(line, tokens, 2, $"{{{{env:{tokens[0].Lexeme.ToUpperInvariant()}}}}}"), true);
+        }
+
+        return (line, false);
+    }
+
+    // A value baked literally into the source (so it would persist), as opposed to an interpolation/handle
+    // that resolves elsewhere.
+    private static bool IsInlineLiteral(TokenKind kind) =>
+        kind is TokenKind.String or TokenKind.Identifier or TokenKind.Integer or TokenKind.Number or TokenKind.Literal;
+
+    // Replaces the source span of token <paramref name="index"/> — [its start column, the next token's start
+    // column) with trailing whitespace trimmed. Using token *boundaries* (not Lexeme length) is robust to the
+    // quote characters and escape decoding that make a string token's Lexeme shorter than its source span.
+    private static string ReplaceTokenSpan(string line, IReadOnlyList<Token> tokens, int index, string replacement)
+    {
+        var start = tokens[index].Location.Column - 1;
+        var end = index + 1 < tokens.Count ? tokens[index + 1].Location.Column - 1 : line.Length;
+        if (start < 0) start = 0;
+        if (end > line.Length) end = line.Length;
+        if (end < start) end = start;
+        while (end > start && char.IsWhiteSpace(line[end - 1])) end--;
+        return line.Substring(0, start) + replacement + line.Substring(end);
+    }
+}

--- a/Vidyano.Script/Runtime/StepResult.cs
+++ b/Vidyano.Script/Runtime/StepResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -18,20 +19,25 @@ public sealed record StatementResult(
     bool Skipped = false);
 
 /// <summary>Aggregate of all <see cref="StatementResult"/>s in one <see cref="Step"/>.
-/// <see cref="Skipped"/> is <c>true</c> when the step had statements and every one was skipped.</summary>
+/// <see cref="Skipped"/> is <c>true</c> when the step had statements and every one was skipped.
+/// <see cref="Duration"/> is the host wall-clock spent in this step — observational, never part of the
+/// reproducible run identity (a JUnit <c>&lt;testcase time&gt;</c> reads it; golden comparisons ignore it).</summary>
 public sealed record StepResult(
     string Label,
     SourceLocation Location,
     bool Ok,
     IReadOnlyList<StatementResult> Statements,
-    bool Skipped = false);
+    bool Skipped = false,
+    TimeSpan Duration = default);
 
-/// <summary>Top-level outcome of running a whole .visc.</summary>
+/// <summary>Top-level outcome of running a whole .visc. <see cref="Duration"/> is the host wall-clock of the
+/// run's statement execution — observational only (see <see cref="StepResult.Duration"/>).</summary>
 public sealed record ScriptResult(
     string SourcePath,
     bool Ok,
     IReadOnlyList<StepResult> Steps,
-    IReadOnlyList<Diagnostic> ParseDiagnostics)
+    IReadOnlyList<Diagnostic> ParseDiagnostics,
+    TimeSpan Duration = default)
 {
     /// <summary>
     /// Renders a plain-text, human-readable report of this run: a header line with the source path

--- a/Vidyano.Script/Runtime/SuiteResult.cs
+++ b/Vidyano.Script/Runtime/SuiteResult.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Vidyano.Script.Runtime;
+
+/// <summary>A discovered .visc unit to run: a display <paramref name="Name"/> (the source path shown in
+/// diagnostics and reports) and the script <paramref name="Body"/>. Decoupled from the file system so a
+/// suite runs from in-memory sources (tests) exactly as it does from disk.</summary>
+public readonly record struct ViscSource(string Name, string Body);
+
+/// <summary>How a single file in a suite ended. Exactly one applies per file; the aggregate process exit
+/// code is a pure function of the set (see <see cref="SuiteExit.CodeFor"/>).</summary>
+public enum FileOutcome
+{
+    /// <summary>Ran clean — every executed statement passed.</summary>
+    Passed,
+    /// <summary>Ran, but at least one assertion or guard check failed.</summary>
+    Failed,
+    /// <summary>Ran, but every statement was skipped by an unmet <c>REQUIRES</c> (nothing was asserted).</summary>
+    Skipped,
+    /// <summary>The per-file timeout fired before the script finished.</summary>
+    Timeout,
+    /// <summary>Never got going against the backend — no base URI, or a transport/connect failure.</summary>
+    Connection,
+    /// <summary>The source did not parse.</summary>
+    Parse,
+}
+
+/// <summary>Outcome of running one file in a suite. <see cref="Script"/> is null when the file never produced
+/// a <see cref="ScriptResult"/> (a timeout, or a transport fault thrown instead of a result); <see cref="Error"/>
+/// then carries the reason. <see cref="Duration"/> is host wall-clock for the whole file (includes connect /
+/// sign-in), distinct from <see cref="ScriptResult.Duration"/> which covers only statement execution.</summary>
+public sealed record FileResult(
+    string Source,
+    FileOutcome Outcome,
+    ScriptResult? Script,
+    TimeSpan Duration,
+    string? Error = null);
+
+/// <summary>Aggregate of every <see cref="FileResult"/> in a suite run, in discovery order.</summary>
+public sealed record SuiteResult(IReadOnlyList<FileResult> Files, TimeSpan Duration)
+{
+    /// <summary>True iff every file passed or was skipped — nothing failed, timed out, or failed to run.</summary>
+    public bool Ok => Files.All(f => f.Outcome is FileOutcome.Passed or FileOutcome.Skipped);
+}
+
+/// <summary>
+/// Derives the process exit code from a finished suite. Pure and total — no I/O, no clock — so the exit
+/// contract (the one thing CI bets the build on) is unit-testable in isolation, the reason the runner is
+/// shaped around a value model rather than side effects.
+/// </summary>
+/// <remarks>
+/// Precedence, most-blocking first: any <see cref="FileOutcome.Connection"/> ⇒ <c>3</c> (the run couldn't
+/// trust the backend, so even green files mean nothing); else any <see cref="FileOutcome.Parse"/> ⇒ <c>2</c>
+/// (malformed input); else any <see cref="FileOutcome.Failed"/> or <see cref="FileOutcome.Timeout"/> ⇒
+/// <c>1</c> (it ran and something went wrong — a timeout is a failure of that test, not the documented
+/// "before any work happened" connection case, so it folds into <c>1</c>, not <c>3</c>); else <c>0</c>.
+/// The codes match the single-file contract in <c>Cli</c> (0 ok / 1 fail / 2 parse / 3 connect).
+/// </remarks>
+public static class SuiteExit
+{
+    public const int Ok = 0;
+    public const int Failed = 1;
+    public const int Parse = 2;
+    public const int Connection = 3;
+
+    public static int CodeFor(SuiteResult suite)
+    {
+        var anyParse = false;
+        var anyFailish = false;
+        foreach (var f in suite.Files)
+        {
+            switch (f.Outcome)
+            {
+                // Most-blocking — short-circuit. Any Connection anywhere outranks Parse/Failed/Timeout.
+                case FileOutcome.Connection: return Connection;
+                case FileOutcome.Parse:      anyParse = true; break;
+                case FileOutcome.Failed:
+                case FileOutcome.Timeout:    anyFailish = true; break;
+            }
+        }
+        if (anyParse) return Parse;
+        if (anyFailish) return Failed;
+        return Ok;
+    }
+}

--- a/Vidyano.Script/Runtime/SuiteRunner.cs
+++ b/Vidyano.Script/Runtime/SuiteRunner.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Vidyano.Script.Diagnostics;
+
+namespace Vidyano.Script.Runtime;
+
+/// <summary>Knobs for a suite run.</summary>
+public sealed record SuiteRunOptions
+{
+    /// <summary>How many files run concurrently. Clamped to ≥ 1. Default 1 (serial) — safe for suites whose
+    /// scripts share server fixtures; the CLI raises it.</summary>
+    public int MaxParallelism { get; init; } = 1;
+
+    /// <summary>Per-file wall-clock budget. A file that exceeds it is cancelled and recorded as
+    /// <see cref="FileOutcome.Timeout"/>. Null (or non-positive) means no per-file limit.</summary>
+    public TimeSpan? PerFileTimeout { get; init; }
+}
+
+/// <summary>
+/// Runs a set of <see cref="ViscSource"/>s through a per-file <paramref name="executor"/> and aggregates the
+/// outcomes into a <see cref="SuiteResult"/>. The executor is the only seam that touches a backend — tests
+/// inject a fake (canned results / delays / throws); production passes <see cref="VidyanoScript.RunSuiteAsync"/>'s
+/// real run. Because the runner depends on nothing but a source list and a delegate, its whole behavior —
+/// classification, timeout, parallelism, ordering — is exercisable in memory with no disk and no network.
+/// </summary>
+public static class SuiteRunner
+{
+    public static async Task<SuiteResult> RunAsync(
+        IReadOnlyList<ViscSource> sources,
+        Func<ViscSource, CancellationToken, Task<ScriptResult>> executor,
+        SuiteRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= new SuiteRunOptions();
+        var degree = Math.Max(1, options.MaxParallelism);
+        var results = new FileResult[sources.Count];
+        var suiteStart = Stopwatch.GetTimestamp();
+
+        using var gate = new SemaphoreSlim(degree);
+        var tasks = new Task[sources.Count];
+        for (var i = 0; i < sources.Count; i++)
+        {
+            var index = i;
+            var source = sources[i];
+            tasks[i] = Task.Run(async () =>
+            {
+                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    results[index] = await RunOneAsync(source, executor, options.PerFileTimeout, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                finally { gate.Release(); }
+            }, cancellationToken);
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        return new SuiteResult(results, Stopwatch.GetElapsedTime(suiteStart));
+    }
+
+    private static async Task<FileResult> RunOneAsync(
+        ViscSource source,
+        Func<ViscSource, CancellationToken, Task<ScriptResult>> executor,
+        TimeSpan? timeout,
+        CancellationToken outer)
+    {
+        var start = Stopwatch.GetTimestamp();
+        using var perFile = CancellationTokenSource.CreateLinkedTokenSource(outer);
+        if (timeout is { } t && t > TimeSpan.Zero)
+            perFile.CancelAfter(t);
+        try
+        {
+            var result = await executor(source, perFile.Token).ConfigureAwait(false);
+            return new FileResult(source.Name, Classify(result), result, Stopwatch.GetElapsedTime(start));
+        }
+        catch (OperationCanceledException) when (perFile.IsCancellationRequested && !outer.IsCancellationRequested)
+        {
+            // Our timeout fired (not a host-driven abort): a Timeout outcome, distinct from an assertion fail.
+            return new FileResult(source.Name, FileOutcome.Timeout, null, Stopwatch.GetElapsedTime(start),
+                timeout is { } to ? $"timed out after {to.TotalSeconds:0.#}s" : "timed out");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The executor faulted before producing a result — almost always a connect/transport failure
+            // (bad host, TLS, DNS). Record Connection so the exit code reflects "couldn't run", not "failed".
+            return new FileResult(source.Name, FileOutcome.Connection, null, Stopwatch.GetElapsedTime(start), ex.Message);
+        }
+        // An OperationCanceledException from the outer (host) token escapes RunAsync and aborts the suite.
+    }
+
+    /// <summary>Maps a completed <see cref="ScriptResult"/> to a <see cref="FileOutcome"/>. Pure — depends only
+    /// on the result's diagnostics and pass/skip flags — so it is unit-testable from fabricated results.</summary>
+    /// <remarks>
+    /// A connect/transport diagnostic wins first, wherever it sits: the no-base-URI case lands in
+    /// <see cref="ScriptResult.ParseDiagnostics"/> with <see cref="ErrorKind.StateNotConnected"/>, while a
+    /// sign-in transport fault lands in a statement's diagnostics — both mean the file never ran against the
+    /// backend, so both are <see cref="FileOutcome.Connection"/> and must be classified before Parse so the
+    /// no-URI sentinel isn't mistaken for malformed syntax. (Timeout is decided by the runner, not here.)
+    /// </remarks>
+    public static FileOutcome Classify(ScriptResult result)
+    {
+        if (!result.Ok && AllDiagnostics(result).Any(d => IsConnect(d.Kind)))
+            return FileOutcome.Connection;
+        if (result.ParseDiagnostics.Count > 0)
+            return FileOutcome.Parse;
+        if (!result.Ok)
+            return FileOutcome.Failed;
+
+        var statements = result.Steps.SelectMany(s => s.Statements).ToList();
+        if (statements.Count > 0 && statements.All(s => s.Skipped))
+            return FileOutcome.Skipped;
+        return FileOutcome.Passed;
+    }
+
+    private static IEnumerable<Diagnostic> AllDiagnostics(ScriptResult r) =>
+        r.ParseDiagnostics.Concat(r.Steps.SelectMany(s => s.Statements).SelectMany(s => s.Diagnostics));
+
+    // A mid-run transport blip folds into Connection too — for CI that's the honest "retry the job" signal,
+    // not "your assertion is wrong". A ServerError (the server rejecting a real operation) stays a Failed.
+    private static bool IsConnect(string kind) =>
+        kind is ErrorKind.StateNotConnected or ErrorKind.TransportError;
+}

--- a/Vidyano.Script/VidyanoScript.cs
+++ b/Vidyano.Script/VidyanoScript.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Vidyano.Script.Diagnostics;
 using Vidyano.Script.Parsing;
@@ -17,7 +18,7 @@ namespace Vidyano.Script;
 public static class VidyanoScript
 {
     /// <summary>Parses and executes a .visc file from disk.</summary>
-    public static Task<ScriptResult> RunFileAsync(string path, VidyanoScriptOptions? options = null)
+    public static Task<ScriptResult> RunFileAsync(string path, VidyanoScriptOptions? options = null, CancellationToken cancellationToken = default)
     {
         if (!File.Exists(path))
             return Task.FromResult(MakeParseOnlyResult(path, new Diagnostic(
@@ -27,11 +28,12 @@ public static class VidyanoScript
         var source = File.ReadAllText(path);
         var opts = options ?? new VidyanoScriptOptions();
         opts.SourcePath = path;
-        return RunAsync(source, opts);
+        return RunAsync(source, opts, cancellationToken);
     }
 
-    /// <summary>Parses and executes a .visc body. <paramref name="options"/> can override the source path.</summary>
-    public static async Task<ScriptResult> RunAsync(string body, VidyanoScriptOptions? options = null)
+    /// <summary>Parses and executes a .visc body. <paramref name="options"/> can override the source path.
+    /// <paramref name="cancellationToken"/> aborts execution — the suite runner uses it for per-file timeouts.</summary>
+    public static async Task<ScriptResult> RunAsync(string body, VidyanoScriptOptions? options = null, CancellationToken cancellationToken = default)
     {
         var opts = options ?? new VidyanoScriptOptions();
         var lexer = new Lexer(body, opts.SourcePath);
@@ -69,7 +71,7 @@ public static class VidyanoScript
 
         try
         {
-            var conn = await adapter.StartAsync().ConfigureAwait(false);
+            var conn = await adapter.StartAsync(cancellationToken).ConfigureAwait(false);
             // The default ("") slot reuses the runner-owned transport (conn.HttpClient); named SIGN-INs
             // mint their OWN cookie jar via the VidyanoSession own-jar ctor branch (the `httpClient: null`
             // path) so each named identity is isolated. mintFresh must never close over conn.HttpClient.
@@ -80,7 +82,7 @@ public static class VidyanoScript
                 initial: initialSession,
                 mintFresh: () => new ValueTask<VidyanoSession>(
                     new VidyanoSession(conn.BaseUri, acceptAnyServerCertificate: opts.AcceptAnyServerCertificate)));
-            var interpreter = new Interpreter(sessions, opts.Variables, opts.Mode, opts.Tools, now: opts.Now, seed: opts.Seed, envLookup: opts.EnvLookup, envPrefix: opts.EnvironmentPrefix);
+            var interpreter = new Interpreter(sessions, opts.Variables, opts.Mode, opts.Tools, cancellationToken: cancellationToken, now: opts.Now, seed: opts.Seed, envLookup: opts.EnvLookup, envPrefix: opts.EnvironmentPrefix);
             return await interpreter.RunAsync(script).ConfigureAwait(false);
         }
         finally
@@ -111,6 +113,34 @@ public static class VidyanoScript
         opts.HttpClient = backend;
         opts.RemoteUri ??= backend.BaseAddress?.ToString();
         return opts;
+    }
+
+    /// <summary>
+    /// Runs a whole suite of .visc sources and aggregates the outcomes. The library entry point behind
+    /// <c>vidyano test</c>: it wires <see cref="SuiteRunner"/>'s per-file executor to <see cref="RunAsync(string, VidyanoScriptOptions, CancellationToken)"/>,
+    /// applying a fresh <see cref="VidyanoScriptOptions"/> per file from <paramref name="optionsFor"/>.
+    /// </summary>
+    /// <param name="optionsFor">Produces the options for each source. MUST return a fresh instance per call —
+    /// files run concurrently (per <paramref name="runOptions"/>) and a shared options object would race on its
+    /// <see cref="VidyanoScriptOptions.Variables"/> / <see cref="VidyanoScriptOptions.Tools"/> tables. The
+    /// source path is stamped automatically. Defaults to a fresh, empty options object per file.</param>
+    public static Task<SuiteResult> RunSuiteAsync(
+        IReadOnlyList<ViscSource> sources,
+        Func<ViscSource, VidyanoScriptOptions>? optionsFor = null,
+        SuiteRunOptions? runOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        optionsFor ??= _ => new VidyanoScriptOptions();
+        return SuiteRunner.RunAsync(
+            sources,
+            (src, ct) =>
+            {
+                var opts = optionsFor(src);
+                opts.SourcePath = src.Name;
+                return RunAsync(src.Body, opts, ct);
+            },
+            runOptions,
+            cancellationToken);
     }
 
     /// <summary>Lints only — returns diagnostics without executing. Parse errors take precedence; when

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,8 @@ Expected: `7/7 ok` — a tick for the `@app` assignment, one per verb, and each 
 ## Commands
 
 ```
-vidyano run   <file.visc> [options]   Execute a script.
+vidyano run   <file.visc> [options]   Execute a single script.
+vidyano test  <path...> [options]     Run a suite (files/dirs/globs); aggregate exit code + reports.
 vidyano lint  <file.visc>             Parse-check without executing.
 vidyano repl  [options]               Start an interactive .visc REPL.
 vidyano lsp                           Run the .visc language server over stdio (for editors).
@@ -44,7 +45,45 @@ vidyano help  [verbs]                 Show help. 'verbs' lists every .visc verb.
 
 `vidyano help verbs` prints the full verb grammar straight from the engine's catalog — the always-current companion to [the language reference](./visc-language.md).
 
-## Options (shared by `run` and `repl`)
+## Running a suite (`test`)
+
+`vidyano run` executes one file; `vidyano test` runs **many** and rolls them up into a single pass/fail with machine-readable reports — the shape CI wants.
+
+```bash
+vidyano test tests/ --app https://demo.vidyano.com/ --report junit:results.xml
+```
+
+**Discovery.** Each positional argument is a file, a directory (recursed for `*.visc`), or a glob (`tests/**/*.visc`, `smoke/*.visc`). Matches are de-duplicated and ordered, so a run — and its reports — are deterministic. Discovering **zero** files is exit `64`, not a green run of nothing.
+
+**Per-file outcome.** Each file ends as exactly one of: passed, failed (an assertion/guard didn't hold), skipped (every statement gated out by `REQUIRES`), timed out (`--timeout`), connection (no base URI, or a transport/sign-in failure), or parse. Each file runs in its **own session** (own cookie jar), so files don't share sign-in state.
+
+**Aggregate exit code** is the most-blocking outcome across the suite — see [Exit codes](#exit-codes).
+
+### `test` options
+
+| Flag | Purpose |
+|---|---|
+| `--report <fmt>[:<path>]` | Emit a report. `<fmt>` is `junit`, `tap`, or `sarif`. Repeatable (emit several at once). With `:<path>` it's written to that file (parent dirs created); bare, it goes to stdout. |
+| `--timeout <dur>` | Per-file wall-clock budget: `30s`, `2m`, `1h`, or `0` (off). A file that exceeds it is cancelled and recorded as a timeout. **Default: off** — the transport already caps each request at 90s, so a hung backend still surfaces; set this only to bound legitimately slow scripts. Also honored by `run`. |
+| `--jobs <n>` | Run up to `n` files concurrently. **Default: 1 (serial)** — safe for suites whose scripts touch shared server fixtures. Raise it when your scripts are independent. Report order is unaffected by `--jobs`. |
+
+All the shared options below (`--app`, `--var`, `--mode`, `--tools`, `--seed`, `--now`, `--env-file`, `--env-prefix`, `--json`, `--verbose`, `--insecure`) apply to `test` too; `--seed` / `--now` are applied per file, so a seeded suite stays reproducible regardless of `--jobs`.
+
+### Report formats
+
+| `--report` | Format | Granularity | For |
+|---|---|---|---|
+| `junit` | JUnit XML | one `<testsuite>` per file, one `<testcase>` per `###` step | GitLab/Jenkins/GitHub test dashboards |
+| `tap` | TAP v13 | one test point per file | TAP consumers, simple CI |
+| `sarif` | SARIF 2.1.0 | one result per failure diagnostic (file + line) | GitHub code scanning |
+
+```bash
+# Two reports at once + parallelism, fail the build on any non-green file:
+vidyano test tests/ --jobs 4 --report junit:out/visc.xml --report sarif:out/visc.sarif
+echo $?   # 0 ok · 1 failed/timeout · 2 parse · 3 connection · 64 no files
+```
+
+## Options (shared by `run`, `test` and `repl`)
 
 | Flag | Purpose |
 |---|---|
@@ -56,7 +95,7 @@ vidyano help  [verbs]                 Show help. 'verbs' lists every .visc verb.
 | `--seed <int>` | Pin `{{@uuid}}` / `{{@random}}` for reproducible runs. |
 | `--env-file <path>` | Load `KEY=VALUE` pairs from a `.env`, backing `{{env:NAME}}` and `SIGN-IN FROM ENV`. Repeatable; last wins. |
 | `--env-prefix <prefix>` | Bind matching process env vars into the variable table, prefix stripped (`VIDYANO_REGION` → `{{REGION}}`). An explicit `--var` wins. |
-| `--json` | NDJSON output — one event per line. Pipe-friendly for CI / agents. |
+| `--json` | NDJSON output — one event per line. Pipe-friendly for CI / agents. `test` wraps each file in `file.start`/`file.end` and ends with a `suite.summary`; `lint` emits `lint.diagnostic`/`lint.summary` (previously `lint` ignored `--json`). |
 | `--verbose` | Print per-statement snapshot detail. |
 | `--insecure` | Bypass TLS validation. **Local dev certs only.** |
 
@@ -65,25 +104,35 @@ vidyano help  [verbs]                 Show help. 'verbs' lists every .visc verb.
 
 `{{env:NAME}}` reads a variable and **loud-fails if unset** (`{{env:NAME ?? "fallback"}}` makes it optional); `SIGN-IN FROM ENV` reads `VIDYANO_USER` / `VIDYANO_PASSWORD`. By default these come from the process environment. `--env-file` layers a `.env` on top (literal `KEY=VALUE`, full-line `#` comments and an optional `export ` prefix; no quote stripping or `${VAR}` expansion), **shadowing** the process environment — repeatable, last file wins per key. `--env-prefix` bulk-binds matching *process* env vars into plain `{{NAME}}` variables (not fed by `--env-file`).
 
+<a id="exit-codes"></a>
 ## Exit codes
 
 | Code | Meaning |
 |---|---|
-| `0` | Everything passed. |
-| `1` | One or more assertions or guard checks failed. |
-| `2` | Parse error — the script didn't make it past the lexer/parser. |
-| `3` | Connection / sign-in failed before any script work happened. |
-| `64` | Bad CLI usage (unknown subcommand, missing argument). |
+| `0` | Everything passed (skipped files are not failures). |
+| `1` | One or more assertions or guard checks failed — or a file timed out. |
+| `2` | Parse error — a script didn't make it past the lexer/parser. |
+| `3` | Connection / sign-in failed — no base URI, or a transport failure. |
+| `64` | Bad CLI usage (unknown subcommand, missing argument, no files discovered). |
+
+For `test`, the code is the **most-blocking** outcome in the suite: any connection failure ⇒ `3`, else any parse error ⇒ `2`, else any failure or timeout ⇒ `1`, else `0`. `run` classifies its single file the same way — so a script with no base URI now correctly exits `3` (it used to report `2`).
 
 ## CI / agent use
 
-`--json` emits NDJSON suitable for piping into a log collector. Each verb produces one event with its result, timing, and any guard violation. Pair it with an exit-code check:
+For a whole regression suite, `vidyano test` is the entry point: point it at a directory, emit JUnit for the dashboard, and let the exit code gate the build.
+
+```bash
+vidyano test tests/ --app "$VIDYANO_URL" --report junit:results.xml
+# upload results.xml as the test report; non-zero exit fails the job
+```
+
+For a single script (or streaming to a log collector), `--json` emits NDJSON — each verb produces one event with its result, timing, and any guard violation:
 
 ```bash
 vidyano run regression.visc --json > run.ndjson || echo "regression failed: $?"
 ```
 
-`lint` (exit code `2` on malformed scripts) runs without a server, so it's a cheap pre-commit / PR gate — it statically catches block-balance (`END` matching) and bound-shape errors in loops.
+`lint` (exit code `2` on malformed scripts) runs without a server, so it's a cheap pre-commit / PR gate — it statically catches block-balance (`END` matching) and bound-shape errors in loops. Add `--json` for machine-readable lint output.
 
 <a id="tool-packs"></a>
 ## Tool packs (external C# logic)


### PR DESCRIPTION
Two independent, well-separated changes (one commit each) — the CI test-runner the script-related `OPTIMIZATIONS.md` leads pointed at, plus the REPL credential-handling security fix flagged alongside them. They share a branch for convenience; `fix(repl)` cherry-picks cleanly onto `main` if you'd rather split.

## 1. `feat(script)` — `vidyano test` suite runner (`a14894c`)

Turns `vidyano` from a single-file runner into a CI-grade test runner.

- **New `vidyano test <path...>`** — file/dir/glob discovery (deterministic order; zero matches → exit 64, not a green run of nothing), per-file outcome classification, aggregate exit code.
- **Reports**: `--report junit|tap|sarif[:path]` (repeatable; bare → stdout) and `lint --json` (previously silently ignored).
- **Timeout / parallelism**: `--timeout <30s|2m|0>` (per-file; off by default — transport already caps 90s/request) and `--jobs <n>` (serial by default; safe for shared fixtures).
- **Exit codes made honest**: pure `SuiteExit.CodeFor` rolls per-file outcomes into `0/1/2/3`; `run` routes its single file through the same `SuiteRunner.Classify`, so a no-base-URI script now exits **3** (was wrongly **2**) and dead exit-3 is finally returned.
- Additive `Duration` on `ScriptResult`/`StepResult` (observational; never in golden compares). Pure, deterministic JUnit/TAP/SARIF formatters.

### Design provenance
Output of `/design-interface` (4 parallel design agents). Chosen: a testable spine (ports as a per-file executor delegate + pure `SuiteExit.CodeFor`) + a common-case CLI; rejected pluggable-DLL reporters (YAGNI) and dropped an `IClock` port (over-abstraction). The design's stated condition — *the ports are only worth it if the in-memory test project ships with them* — is satisfied below.

## 2. `fix(repl)` — keep plaintext credentials out of `:save` / `:vars` (`599bdc3`)

The REPL wrote raw history verbatim, so a typed `SIGN-IN admin / vidyano` persisted a plaintext password into the saved `.visc` (often committed); `:vars` echoed secret-named values.

- **New `ScriptSecrets`** (engine): `RedactLine` rewrites an inline SIGN-IN password → `{{env:VIDYANO_PASSWORD}}` and a secret-named literal assignment → `{{env:NAME}}` — secure **and** still runnable via env. Token-boundary based, so quoted/escaped passwords redact exactly; menu-path slashes and existing `{{env:…}}` are left alone.
- `:save` redacts by default; **`:save <path> --raw`** opts into verbatim with a warning. `:vars` masks secret-named values.

## Verification
- Full **Release** build across all target frameworks — 0 errors.
- **405/405** tests pass (59 new: suite exit/classify/runner + JUnit/TAP/SARIF + redaction). The runner, classifier, exit-code function, formatters, and redaction are all exercised **in memory** — no server, no disk.
- CLI smoke-tested: exit `0/1/2/3/64`, JUnit/TAP/SARIF output, `--json`, globs, `run` exit-3 fix, and the REPL `:save`/`:vars` redaction end-to-end.

## Docs
`docs/cli.md` (suite section, options, exit codes, CI) and project `CLAUDE.md` updated; REPL `:help` documents `--raw` and masking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)