### PR TITLE
refactor: async-only attribute value setting; remove dead REFRESH verb

### DIFF
--- a/Vidyano.Core/ViewModel/PersistentObject.cs
+++ b/Vidyano.Core/ViewModel/PersistentObject.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -475,9 +476,13 @@ namespace Vidyano.ViewModel
             }
         }
 
-        public async Task RefreshAttributesAsync(PersistentObjectAttribute attribute = null)
+        // Server-driven attribute refresh after a TriggersRefresh attribute changes. Not a caller-facing
+        // operation: it's the synchronization step behind PersistentObjectAttribute.SetValueAsync, which
+        // owns the value change that warrants it — hence internal and a required attribute (the server
+        // needs RefreshedPersistentObjectAttributeId to know which attribute fired).
+        internal async Task RefreshAttributesAsync(PersistentObjectAttribute attribute)
         {
-            var parameters = attribute != null ? new Dictionary<string, string> { { "RefreshedPersistentObjectAttributeId", Client.ToServiceString(attribute.Id) } } : null;
+            var parameters = new Dictionary<string, string> { { "RefreshedPersistentObjectAttributeId", Client.ToServiceString(attribute.Id) } };
             try
             {
                 var result = await Client.ExecuteActionAsync("PersistentObject.Refresh", this, null, null, parameters).ConfigureAwait(false);
@@ -533,11 +538,20 @@ namespace Vidyano.ViewModel
             return Queries[queryName];
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use SetAttributeValueAsync instead to ensure the UI is properly refreshed when the value changes. This method will not trigger a refresh and may cause the UI to be out of sync with the underlying data.", true)]
         public void SetAttributeValue(string attributeName, object value)
+        {
+            _ = SetAttributeValueAsync(attributeName, value);
+        }
+
+        public Task SetAttributeValueAsync(string attributeName, object value)
         {
             var attr = GetAttribute(attributeName);
             if (attr != null)
-                attr.Value = value;
+                return attr.SetValueAsync(value);
+
+            return Task.CompletedTask;
         }
 
         #region Service Serialization

--- a/Vidyano.Core/ViewModel/PersistentObject.cs
+++ b/Vidyano.Core/ViewModel/PersistentObject.cs
@@ -486,6 +486,8 @@ namespace Vidyano.ViewModel
             try
             {
                 var result = await Client.ExecuteActionAsync("PersistentObject.Refresh", this, null, null, parameters).ConfigureAwait(false);
+                if (result == null)
+                    return;
 
                 SetNotification(result.Notification, result.NotificationType);
 

--- a/Vidyano.Core/ViewModel/PersistentObjectAttribute.cs
+++ b/Vidyano.Core/ViewModel/PersistentObjectAttribute.cs
@@ -76,7 +76,10 @@ namespace Vidyano.ViewModel
         public Option SelectedOption
         {
             get { return Options.FirstOrDefault(o => o.Key == ValueDirect); }
-            set => Value = value?.Key;
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [Obsolete("Use SetValueAsync instead to ensure the UI is properly refreshed when the value changes. This method will not trigger a refresh and may cause the UI to be out of sync with the underlying data.", true)]
+            set => _ = SetValueAsync(value?.Key);
         }
 
         public string GroupName => GetProperty<string>("Group");
@@ -159,14 +162,12 @@ namespace Vidyano.ViewModel
         public object Value
         {
             get { return Client.FromServiceString(GetProperty<string>(), Type); }
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [Obsolete("Use SetValueAsync instead to ensure the UI is properly refreshed when the value changes. This method will not trigger a refresh and may cause the UI to be out of sync with the underlying data.", true)]
             set
             {
-                if (UpdateValue(value) && Parent != null && TriggersRefresh)
-                {
-#pragma warning disable 4014
-                    Parent.RefreshAttributesAsync(this);
-#pragma warning restore 4014
-                }
+                _ = SetValueAsync(value);
             }
         }
 

--- a/Vidyano.Script.IntegrationTests/InProcessVidyanoBackend.cs
+++ b/Vidyano.Script.IntegrationTests/InProcessVidyanoBackend.cs
@@ -66,6 +66,12 @@ public sealed class InProcessVidyanoBackend : IBackendAdapter
                 model.GetPersistentObject(nameof(ProductCategory))!
                     .GetOrCreateAttributeAsDetail("Products").Details = productsDetail;
 
+                // Mark Product.Trigger as TriggersRefresh: a SET of it round-trips through
+                // ProductActions.OnRefresh, which mirrors the value into Product.Echo — exercises the
+                // client SetValueAsync -> RefreshAttributesAsync path end-to-end.
+                model.GetPersistentObject(nameof(Product))!
+                    .GetOrCreateAttribute(nameof(Product.Trigger)).TriggersRefresh = true;
+
                 // Query-level custom actions. The user right both authorizes the action and attaches it
                 // to the Product query's PO type.
                 var hello = model.GetOrCreateCustomAction(nameof(HelloWorld));

--- a/Vidyano.Script.IntegrationTests/ShopContext.cs
+++ b/Vidyano.Script.IntegrationTests/ShopContext.cs
@@ -94,6 +94,17 @@ public sealed class Product
     public string Color { get; set; } = string.Empty;
     [Reference(typeof(ProductCategory))]
     public string? Category { get; set; }
+
+    // Nullable (like Category) so they're optional — a non-nullable string would be a required
+    // attribute and the empty seed value would fail SAVE validation in the other Product tests.
+
+    /// <summary>Marked <c>TriggersRefresh</c> in the model (see <see cref="InProcessVidyanoBackend"/>);
+    /// setting it fires <see cref="ProductActions.OnRefresh"/>.</summary>
+    public string? Trigger { get; set; }
+
+    /// <summary>The "different attribute" the refresh writes: <see cref="ProductActions.OnRefresh"/>
+    /// mirrors <see cref="Trigger"/> into it, so a SET of Trigger surfaces here after the round-trip.</summary>
+    public string? Echo { get; set; }
 }
 
 public sealed class ProductCategory
@@ -130,6 +141,18 @@ public sealed class ProductActions(ShopContext context)
         }
 
         base.OnSave(obj);
+    }
+
+    /// <summary>Fires when a <c>TriggersRefresh</c> attribute changes. When it's <see cref="Product.Trigger"/>,
+    /// mirror the new value into the unrelated <see cref="Product.Echo"/> attribute. This is the server
+    /// half of the client refresh round-trip: a SET of Trigger calls PersistentObject.Refresh, OnRefresh
+    /// mutates a *different* attribute, and the refreshed Echo flows back so EXPECT can read it.</summary>
+    public override void OnRefresh(RefreshArgs args)
+    {
+        base.OnRefresh(args);
+
+        if (args.Attribute?.Name == nameof(Product.Trigger))
+            args.PersistentObject.SetAttributeValue(nameof(Product.Echo), $"echo:{(string?)args.PersistentObject[nameof(Product.Trigger)]}");
     }
 
     /// <summary>Detail query: the products belonging to one category. Auto-discovered by name and

--- a/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
+++ b/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
@@ -106,6 +106,23 @@ public sealed class VerbFamilyTests
     }
 
     [Fact]
+    public async Task TriggersRefresh_OnRefresh_UpdatesOtherAttribute()
+    {
+        // Setting Product.Trigger (marked TriggersRefresh) round-trips through ProductActions.OnRefresh,
+        // which mirrors it into the unrelated Product.Echo. Regression for the client refresh path:
+        // SET -> SetValueAsync -> RefreshAttributesAsync, with the server-modified Echo flowing back so
+        // EXPECT sees a value the SET itself never wrote.
+        AssertOk(await Run("""
+            SIGN-IN admin / admin
+            OPEN MenuItem Home/Products
+            OPEN-ROW WHERE Name = "Widget"
+            EDIT
+            SET Trigger = "Purple"
+            EXPECT Echo = "echo:Purple"
+            """));
+    }
+
+    [Fact]
     public async Task Follow_Reference_OpensTarget()
     {
         AssertOk(await Run("""

--- a/Vidyano.Script.Tests/GrammarRefreshLintTests.cs
+++ b/Vidyano.Script.Tests/GrammarRefreshLintTests.cs
@@ -288,15 +288,4 @@ public sealed class GrammarRefreshLintTests
         AssertClean("SET Whatever = ID \"x\"");
         AssertClean("SET Whatever = null");
     }
-
-    // --- REFRESH (regression: keyword still parses) --------------------------------------------
-
-    [Fact]
-    public void Refresh_BareVerb_StillParses()
-    {
-        // The help-table row for REFRESH was removed but the verb itself was kept; verify the
-        // parser still produces a RefreshStmt rather than an unknown-verb diagnostic.
-        var stmt = SingleStatement<RefreshStmt>("REFRESH");
-        Assert.Null(stmt.Handle);
-    }
 }

--- a/Vidyano.Script.Tests/VerbCatalogReconciliationTests.cs
+++ b/Vidyano.Script.Tests/VerbCatalogReconciliationTests.cs
@@ -18,7 +18,7 @@ public sealed class VerbCatalogReconciliationTests
     private static readonly string[] HistoricalKnownVerbs =
     [
         "SIGN-IN", "SIGN-OUT", "USE", "OPEN", "OPEN-ROW", "GO-BACK", "FOLLOW",
-        "EDIT", "CANCEL", "SAVE", "REFRESH",
+        "EDIT", "CANCEL", "SAVE",
         "SET", "ACTION", "CONFIRM", "SEARCH", "SELECT-ROWS",
         "EXPECT",
         "TOOL",

--- a/Vidyano.Script.Tool/ConsoleReporter.cs
+++ b/Vidyano.Script.Tool/ConsoleReporter.cs
@@ -88,7 +88,6 @@ public static class ConsoleReporter
             EditStmt                   => "EDIT",
             CancelStmt                 => "CANCEL",
             SaveStmt sv                => sv.ExpectError ? "SAVE EXPECTING ERROR" : "SAVE",
-            RefreshStmt                => "REFRESH",
             SetStmt s                  => $"SET {Markup.Escape(s.Attribute)} = …",
             ActionStmt a               => $"ACTION {Markup.Escape(a.ActionName)}{(a.ExpectError ? " EXPECTING ERROR" : "")}",
             SearchStmt q               => q.DetailName is null ? "SEARCH …" : $"SEARCH Detail \"{Markup.Escape(q.DetailName)}\" …",
@@ -212,8 +211,6 @@ public static class ConsoleReporter
                 return $"error as expected{Notif(snap)}";
             case SaveStmt:
                 return $"saved{Notif(snap)}";
-            case RefreshStmt:
-                return snap?.Po is { } por ? $"refreshed {PoLine(por)}" : "refreshed";
             case SetStmt set:
                 return SetLine(set, snap);
             case ActionStmt { ExpectError: true }:

--- a/Vidyano.Script/Diagnostics/VerbCatalog.cs
+++ b/Vidyano.Script/Diagnostics/VerbCatalog.cs
@@ -23,8 +23,8 @@ public sealed record VerbInfo(
 /// can never drift between those surfaces again.
 /// </summary>
 /// <remarks>
-/// Historically there were two diverging lists: <c>Parser.KnownVerbs</c> (which carried
-/// <c>FOLLOW</c>/<c>REFRESH</c>) and the Tool's
+/// Historically there were two diverging lists: <c>Parser.KnownVerbs</c> (which carried verbs such as
+/// <c>FOLLOW</c>) and the Tool's
 /// syntax-form-keyed help table (which did not). This catalog reconciles them: it is keyed by bare
 /// verb name and MUST contain every verb the parser recognizes. The catalog-reconciliation guard test
 /// asserts that <c>Parser.KnownVerbs ⊆ VerbCatalog.Names</c>.
@@ -123,13 +123,6 @@ public static class VerbCatalog
             "Saves pending edits. `SAVE EXPECTING ERROR` asserts the negative path: it passes only if the "
             + "server returns an error notification, and fails if the save unexpectedly succeeds.",
             ["SAVE", "SAVE EXPECTING ERROR"],
-            "edit", []),
-
-        new("REFRESH",
-            "REFRESH",
-            "Re-fetch the current PO/query from the server.",
-            null,
-            ["REFRESH"],
             "edit", []),
 
         new("SET",

--- a/Vidyano.Script/Parsing/Ast.cs
+++ b/Vidyano.Script/Parsing/Ast.cs
@@ -121,9 +121,6 @@ public sealed record CancelStmt(string? Handle, SourceLocation Location) : State
 /// notification stays on the PO so a following <c>EXPECT Notification …</c> can pin the message.</summary>
 public sealed record SaveStmt(string? Handle, SourceLocation Location, string? Scope = null, bool ExpectError = false) : Statement(Location);
 
-/// <summary><c>REFRESH</c> — refresh attributes (calls <c>PersistentObject.Refresh</c>).</summary>
-public sealed record RefreshStmt(string? Handle, SourceLocation Location) : Statement(Location);
-
 /// <summary>How a <c>SET</c> turns its right-hand side into the attribute value.</summary>
 public enum SetValueKind
 {

--- a/Vidyano.Script/Parsing/Parser.cs
+++ b/Vidyano.Script/Parsing/Parser.cs
@@ -146,7 +146,6 @@ public sealed class Parser
             "EDIT"        => new EditStmt(null, tok.Location),
             "CANCEL"      => new CancelStmt(null, tok.Location),
             "SAVE"        => ParseSave(tok.Location),
-            "REFRESH"     => new RefreshStmt(null, tok.Location),
             "SET"         => ParseSet(tok.Location),
             "ACTION"      => ParseAction(tok.Location),
             "CONFIRM"     => ParseConfirm(tok.Location),

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -329,7 +329,6 @@ public sealed class Interpreter
                         : await Current.SaveAsync(sv.Location).ConfigureAwait(false);
                     return sv.ExpectError ? WrapExpectingError(stmt, saveRes) : Wrap(stmt, saveRes);
                 }
-            case RefreshStmt rf:               return Wrap(stmt, await Current.RefreshAsync(rf.Location).ConfigureAwait(false));
             case SetStmt s:                    return await DoSet(s).ConfigureAwait(false);
             case ActionStmt a:                 return await DoAction(a).ConfigureAwait(false);
             case ConfirmStmt cf:               return await DoConfirm(cf).ConfigureAwait(false);

--- a/Vidyano.Script/Runtime/VidyanoSession.cs
+++ b/Vidyano.Script/Runtime/VidyanoSession.cs
@@ -42,10 +42,10 @@ public sealed class VidyanoSession : IDisposable
     // The "is a retry from MY action?" gate is _withinInflight, an AsyncLocal set only inside the parkable
     // body (StartInflight). It flows into the action's async tree — and into the resumed continuation after
     // CONFIRM, since ExecutionContext is captured at each await — so a retry the action itself raises parks.
-    // It is NOT seen by the interpreter's own context, so an out-of-band server call started off that
-    // context — notably the FIRE-AND-FORGET PersistentObject.Refresh that a SET of a TriggersRefresh
-    // attribute kicks off (PersistentObjectAttribute.Value setter) while the dialog is open — auto-cancels
-    // ("-1") instead of racing into the hook and hijacking the park. A plain bool gate could not tell the
+    // It is NOT seen by the interpreter's own context, so a server call made off that context — notably
+    // the PersistentObject.Refresh that a SET of a TriggersRefresh attribute awaits
+    // (PersistentObjectAttribute.SetValueAsync) while the dialog is open — auto-cancels ("-1") if it
+    // raises its own retry, instead of hijacking the parked dialog. A plain bool gate could not tell the
     // two apart; AsyncLocal is also flow-isolated, so no volatile/barrier is needed on the gate.
     private readonly AsyncLocal<bool> _withinInflight = new();
     private volatile bool _disposing;                    // set in Dispose so a drained action's further retries cancel
@@ -987,20 +987,6 @@ public sealed class VidyanoSession : IDisposable
         }
     }
 
-    public async Task<OpResult> RefreshAsync(SourceLocation loc)
-    {
-        if (CurrentPo is null) return NoCurrentPo(loc);
-        try
-        {
-            await CurrentPo.RefreshAttributesAsync().ConfigureAwait(false);
-            return OpResult.Success;
-        }
-        catch (Exception ex)
-        {
-            return OpResult.Fail(new Diagnostic(ErrorKind.ServerError, ex.Message, loc));
-        }
-    }
-
     // --- set / action -------------------------------------------------------------------------
 
     /// <summary>
@@ -1077,7 +1063,7 @@ public sealed class VidyanoSession : IDisposable
         {
             var formatted = FormatFileValue(attr.Type, attr.Name, f.FileName, f.Data, loc);
             if (!formatted.Ok) return OpResult.Fail(formatted.Error!);
-            attr.Value = formatted.Value;
+            await attr.SetValueAsync(formatted.Value).ConfigureAwait(false);
             return OpResult.Success;
         }
 
@@ -1092,11 +1078,11 @@ public sealed class VidyanoSession : IDisposable
             var text = value as string ?? value?.ToString() ?? "";
             var resolved = ResolveOption(options, text, hint.Kind, loc, attr.Name);
             if (!resolved.Ok) return OpResult.Fail(resolved.Error!);
-            attr.Value = resolved.Value;
+            await attr.SetValueAsync(resolved.Value).ConfigureAwait(false);
             return OpResult.Success;
         }
 
-        attr.Value = value;
+        await attr.SetValueAsync(value).ConfigureAwait(false);
         return OpResult.Success;
     }
 

--- a/editors/visualstudio/visc.tmLanguage.json
+++ b/editors/visualstudio/visc.tmLanguage.json
@@ -56,7 +56,7 @@
     },
     "verb": {
       "name": "keyword.control.visc",
-      "match": "(?i)(?<![\\w-])(?:SIGN-IN|SIGN-OUT|OPEN-ROW|GO-BACK|SELECT-ROWS|FOR-EACH|OPEN|USE|FOLLOW|EDIT|CANCEL|SAVE|REFRESH|SET|ACTION|CONFIRM|SEARCH|EXPECT|TOOL|REQUIRES|CLEANUP|REPEAT)(?![\\w-])"
+      "match": "(?i)(?<![\\w-])(?:SIGN-IN|SIGN-OUT|OPEN-ROW|GO-BACK|SELECT-ROWS|FOR-EACH|OPEN|USE|FOLLOW|EDIT|CANCEL|SAVE|SET|ACTION|CONFIRM|SEARCH|EXPECT|TOOL|REQUIRES|CLEANUP|REPEAT)(?![\\w-])"
     },
     "sub-keyword": {
       "name": "keyword.other.visc",

--- a/editors/vscode/syntaxes/visc.tmLanguage.json
+++ b/editors/vscode/syntaxes/visc.tmLanguage.json
@@ -56,7 +56,7 @@
     },
     "verb": {
       "name": "keyword.control.visc",
-      "match": "(?i)(?<![\\w-])(?:SIGN-IN|SIGN-OUT|OPEN-ROW|GO-BACK|SELECT-ROWS|FOR-EACH|OPEN|USE|FOLLOW|EDIT|CANCEL|SAVE|REFRESH|SET|ACTION|CONFIRM|SEARCH|EXPECT|TOOL|REQUIRES|CLEANUP|REPEAT)(?![\\w-])"
+      "match": "(?i)(?<![\\w-])(?:SIGN-IN|SIGN-OUT|OPEN-ROW|GO-BACK|SELECT-ROWS|FOR-EACH|OPEN|USE|FOLLOW|EDIT|CANCEL|SAVE|SET|ACTION|CONFIRM|SEARCH|EXPECT|TOOL|REQUIRES|CLEANUP|REPEAT)(?![\\w-])"
     },
     "sub-keyword": {
       "name": "keyword.other.visc",


### PR DESCRIPTION
## Summary

Finishes the cleanup so setting an attribute value goes **exclusively through the async path** — a `TriggersRefresh` round-trip is now *awaited* instead of fire-and-forget — and removes the dead `.visc` `REFRESH` verb.

### Core: async-only value setting (breaking)
- `PersistentObjectAttribute.Value` / `SelectedOption` setters and `PersistentObject.SetAttributeValue(...)` are now `[Obsolete(..., error: true)]`. Callers use `SetValueAsync` / `SetAttributeValueAsync`.
- `RefreshAttributesAsync` is now **`internal`** and **requires** the triggering `PersistentObjectAttribute` (the server needs `RefreshedPersistentObjectAttributeId`). Its only caller is `SetValueAsync`.

### Script: remove the `REFRESH` verb end-to-end
It was already hidden from the help table but still parsed. Removed from: `Ast`, `Parser`, `Interpreter`, the `VidyanoSession` handler, `VerbCatalog` (which drives `Parser.KnownVerbs`), `ConsoleReporter`, **both** TextMate grammars (kept byte-identical), and the reconciliation / grammar guard tests.

> The separate `EXPECT ClientOperation Refresh` feature (an operation-type assertion) is **untouched** — only the verb was removed.

### Test: integration coverage for the refresh round-trip
New `TriggersRefresh_OnRefresh_UpdatesOtherAttribute` in `VerbFamilyTests`, driving the real in-process Vidyano server. `Product.Trigger` is marked `TriggersRefresh`; the server `OnRefresh` mirrors it into a *different* attribute (`Product.Echo`). Since the client never writes `Echo`, the assertion only passes if `SET → SetValueAsync → (awaited) RefreshAttributesAsync` round-trips and the server-modified value flows back — exactly the regression this guards.

```
EDIT
SET Trigger = "Purple"
EXPECT Echo = "echo:Purple"
```

## ⚠️ Breaking changes
- `RefreshAttributesAsync` is now `internal`.
- The obsolete value setters (`Value` / `SelectedOption` / `SetAttributeValue`) are **compile errors**.
- The `REFRESH` `.visc` verb no longer exists.

## Test plan
- ✅ `dotnet build Vidyano.Core.sln -c Debug` — 0 errors (clean build confirms no remaining callers of the obsolete setters)
- ✅ Unit: 435 passed (`Vidyano.Script.Tests`)
- ✅ Integration: 11 passed (`Vidyano.Script.IntegrationTests`, incl. the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)