### PR TITLE
fix(visc): tier hidden-attribute SET/read with the guard mode

### DIFF
--- a/Vidyano.Script.IntegrationTests/ShopContext.cs
+++ b/Vidyano.Script.IntegrationTests/ShopContext.cs
@@ -105,6 +105,13 @@ public sealed class Product
     /// <summary>The "different attribute" the refresh writes: <see cref="ProductActions.OnRefresh"/>
     /// mirrors <see cref="Trigger"/> into it, so a SET of Trigger surfaces here after the round-trip.</summary>
     public string? Echo { get; set; }
+
+    /// <summary>A hidden-but-editable attribute: <see cref="ProductActions.OnLoad"/> sets its
+    /// <c>Visibility</c> to <see cref="AttributeVisibility.Never"/>, modelling the real-world case where a
+    /// custom web component edits a field the default editor never renders. The standard UI can't set it,
+    /// so the .visc SET guard tiers by mode (navigation rejects; audit warns-but-allows; direct allows).
+    /// Nullable/optional so it doesn't affect SAVE validation in the other Product tests.</summary>
+    public string? Secret { get; set; }
 }
 
 public sealed class ProductCategory
@@ -130,6 +137,16 @@ public sealed class ProductActions(ShopContext context)
 
         obj.SetAttributeValue("Name", "New Product");
         obj.SetAttributeValue("Color", "Blue");
+    }
+
+    /// <summary>Hides <see cref="Product.Secret"/> from the default editor (visibility Never) the same way a
+    /// real app would for a field only a custom web component edits. The attribute still rides the wire and
+    /// stays editable server-side, so a .visc SET reaches it once the mode allows a hidden write.</summary>
+    public override void OnLoad(PersistentObject obj, PersistentObject? parent)
+    {
+        base.OnLoad(obj, parent);
+
+        obj[nameof(Product.Secret)].Visibility = AttributeVisibility.Never;
     }
 
     public override void OnSave(PersistentObject obj)

--- a/Vidyano.Script.IntegrationTests/ShopContext.cs
+++ b/Vidyano.Script.IntegrationTests/ShopContext.cs
@@ -112,6 +112,12 @@ public sealed class Product
     /// so the .visc SET guard tiers by mode (navigation rejects; audit warns-but-allows; direct allows).
     /// Nullable/optional so it doesn't affect SAVE validation in the other Product tests.</summary>
     public string? Secret { get; set; }
+
+    /// <summary>A visible-but-read-only attribute: <see cref="ProductActions.OnLoad"/> sets its
+    /// <c>IsReadOnly</c>. Read-only is a hard guard the mode tier never relaxes (unlike visibility), so a
+    /// SET of this fails with <c>guard-attribute-read-only</c> even in <c>direct</c> mode. Visible so the
+    /// read-only guard is what's exercised, not the hidden one.</summary>
+    public string? Locked { get; set; }
 }
 
 public sealed class ProductCategory
@@ -147,6 +153,7 @@ public sealed class ProductActions(ShopContext context)
         base.OnLoad(obj, parent);
 
         obj[nameof(Product.Secret)].Visibility = AttributeVisibility.Never;
+        obj[nameof(Product.Locked)].IsReadOnly = true;
     }
 
     public override void OnSave(PersistentObject obj)

--- a/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
+++ b/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
@@ -260,6 +260,25 @@ public sealed class VerbFamilyTests
     }
 
     [Fact]
+    public async Task ReadOnlyAttribute_DirectMode_StillRejected()
+    {
+        // Read-only is the hard guard the mode tier never relaxes: a read-only attribute is genuinely not
+        // settable (even by a custom component), so direct — the most permissive mode — still rejects it.
+        // This pins that the hidden-attribute escape hatch did not also widen the read-only guard.
+        var result = await Run("""
+            @mode = direct
+            SIGN-IN admin / admin
+            OPEN MenuItem Home/Products
+            OPEN-ROW WHERE Name = "Widget"
+            EDIT
+            SET Locked = "tampered"
+            """);
+
+        Assert.False(result.Ok, result.Describe());
+        Assert.Contains(AllDiagnostics(result), d => d.Kind == ErrorKind.GuardAttributeReadOnly);
+    }
+
+    [Fact]
     public async Task NamedSessions_AreIsolated()
     {
         // Two named identities over the SAME in-process server, each with its own cookie jar (minted via

--- a/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
+++ b/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
@@ -1,3 +1,4 @@
+using Vidyano.Script.Diagnostics;
 using Vidyano.Script.Runtime;
 using Xunit;
 
@@ -28,6 +29,12 @@ public sealed class VerbFamilyTests
     }
 
     private static void AssertOk(ScriptResult result) => Assert.True(result.Ok, result.Describe());
+
+    /// <summary>Every diagnostic across every statement of the run — failures, skips, and warnings that
+    /// rode on passing statements alike. Lets a test assert on a specific <see cref="ErrorKind"/> without
+    /// re-walking the step/statement tree each time.</summary>
+    private static IEnumerable<Diagnostic> AllDiagnostics(ScriptResult result) =>
+        result.Steps.SelectMany(s => s.Statements).SelectMany(s => s.Diagnostics);
 
     [Fact]
     public async Task SignIn_Open_QueryCount()
@@ -184,6 +191,72 @@ public sealed class VerbFamilyTests
             EXPECT Notification.Type = "OK"
             EXPECT Notification MATCHES "Yes"
             """));
+    }
+
+    // --- hidden-attribute SET across guard modes -------------------------------------------------
+    //
+    // Product.Secret is hidden (ProductActions.OnLoad sets Visibility = Never), modelling a field only a
+    // custom web component edits. Core itself never blocks setting a hidden-but-editable attribute
+    // (PersistentObjectAttribute.UpdateValue gates on read-only alone), so these pin the .visc SET guard:
+    // it tiers with reachability — navigation rejects, audit warns-but-allows, direct allows silently.
+
+    [Fact]
+    public async Task HiddenAttribute_NavigationMode_RejectsSet()
+    {
+        // Default mode. The standard UI would never surface Secret, so SET is rejected before it touches
+        // the value — the regression that would have let this through is exactly the one the users hit.
+        var result = await Run("""
+            SIGN-IN admin / admin
+            OPEN MenuItem Home/Products
+            OPEN-ROW WHERE Name = "Widget"
+            EDIT
+            SET Secret = "classified"
+            """);
+
+        Assert.False(result.Ok, result.Describe());
+        Assert.Contains(AllDiagnostics(result), d => d.Kind == ErrorKind.GuardAttributeHidden);
+    }
+
+    [Fact]
+    public async Task HiddenAttribute_DirectMode_AllowsAndRoundTrips()
+    {
+        // @mode = direct is the documented escape hatch for the custom-component path: SET reaches the
+        // hidden attribute, SAVE posts it, and reopening reads it back (the EXPECT read tiers the same way).
+        AssertOk(await Run("""
+            @mode = direct
+            SIGN-IN admin / admin
+            OPEN MenuItem Home/Products
+            OPEN-ROW WHERE Name = "Widget"
+            EDIT
+            SET Secret = "classified"
+            SAVE
+            SEARCH ""
+            OPEN-ROW WHERE Name = "Widget"
+            EXPECT Secret = "classified"
+            """));
+    }
+
+    [Fact]
+    public async Task HiddenAttribute_AuditMode_WarnsButAllows()
+    {
+        // Audit tier: the set is allowed (so the round-trip persists like direct) but carries a non-failing
+        // warning so a reviewer sees the custom-component path was exercised.
+        var result = await Run("""
+            @mode = audit
+            SIGN-IN admin / admin
+            OPEN MenuItem Home/Products
+            OPEN-ROW WHERE Name = "Widget"
+            EDIT
+            SET Secret = "classified"
+            SAVE
+            SEARCH ""
+            OPEN-ROW WHERE Name = "Widget"
+            EXPECT Secret = "classified"
+            """);
+
+        AssertOk(result);
+        // The warning rides on the (passing) SET — same kind as the navigation failure, but the run is ok.
+        Assert.Contains(AllDiagnostics(result), d => d.Kind == ErrorKind.GuardAttributeHidden);
     }
 
     [Fact]

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -594,15 +594,15 @@ public sealed class Interpreter
             if (!file.Ok) return Fail(s, file.Error!);
             var (fileName, bytes) = file.Value;
             var fileRes = s.Scope is null
-                ? await Current.SetFileAttributeAsync(s.Attribute, fileName, bytes, s.Location).ConfigureAwait(false)
-                : await Current.SetScopedFileAttributeAsync(s.Scope, s.Attribute, fileName, bytes, s.Location).ConfigureAwait(false);
+                ? await Current.SetFileAttributeAsync(s.Attribute, fileName, bytes, s.Location, _mode).ConfigureAwait(false)
+                : await Current.SetScopedFileAttributeAsync(s.Scope, s.Attribute, fileName, bytes, s.Location, _mode).ConfigureAwait(false);
             return Wrap(s, fileRes);
         }
 
         ReferenceHint? hint = s.Hint is null ? null : new ReferenceHint(s.Hint.Value, AsString(v.Value));
         var res = s.Scope is null
-            ? await Current.SetAttributeAsync(s.Attribute, v.Value, s.Location, hint).ConfigureAwait(false)
-            : await Current.SetScopedAttributeAsync(s.Scope, s.Attribute, v.Value, hint, s.Location).ConfigureAwait(false);
+            ? await Current.SetAttributeAsync(s.Attribute, v.Value, s.Location, _mode, hint).ConfigureAwait(false)
+            : await Current.SetScopedAttributeAsync(s.Scope, s.Attribute, v.Value, hint, s.Location, _mode).ConfigureAwait(false);
         return Wrap(s, res);
     }
 
@@ -1080,10 +1080,15 @@ public sealed class Interpreter
                             $"Attribute '{subj.Name}' does not exist on {po.Type}.",
                             loc,
                             Hint: Suggester.Hint(subj.Name!, po.Attributes.Select(a => a.Name))));
-                    if (!attr.IsVisible)
+                    // Reading a hidden attribute tiers the same way SET does (see SetAttributeOnAsync): the
+                    // standard UI can't read it, but a custom web component can — so navigation rejects while
+                    // audit/direct allow. No audit warning here: a read is observational, so unlike the
+                    // mutating SET it carries no "you touched a hidden field" risk worth surfacing.
+                    if (!attr.IsVisible && _mode == GuardMode.Navigation)
                         return Fail<object?>(new Diagnostic(ErrorKind.GuardAttributeHidden,
-                            $"Attribute '{subj.Name}' exists on {po.Type} but is hidden — the UI cannot read it.",
-                            loc));
+                            $"Attribute '{subj.Name}' exists on {po.Type} but is hidden — the standard UI cannot read it.",
+                            loc,
+                            Hint: "A custom web component can still read a hidden attribute; use @mode = direct (or audit) to read it here."));
                     return AttributeComparand(attr, subj.Hint, loc);
                 }
             case ExpectSubjectKind.Action:
@@ -1778,7 +1783,7 @@ public sealed class Interpreter
     // --- statement result wrappers ------------------------------------------------------------
 
     private StatementResult Wrap(Statement stmt, OpResult res) =>
-        res.Ok ? Ok(stmt) : Fail(stmt, res.Error!);
+        res.Ok ? Ok(stmt, res.Warning) : Fail(stmt, res.Error!);
 
     /// <summary>Same polarity as the non-generic <see cref="Wrap(Statement, OpResult)"/>, for the
     /// <see cref="SessionBook"/> calls that return a payload the interpreter doesn't need (the slot is
@@ -1808,8 +1813,9 @@ public sealed class Interpreter
             : Fail(stmt, res.Error!);
     }
 
-    private StatementResult Ok(Statement stmt) =>
-        new(stmt, true, Current.TakeSnapshot(), Array.Empty<Diagnostic>());
+    private StatementResult Ok(Statement stmt, Diagnostic? warning = null) =>
+        new(stmt, true, Current.TakeSnapshot(),
+            warning is null ? Array.Empty<Diagnostic>() : new[] { warning });
 
     private StatementResult Fail(Statement stmt, Diagnostic d) =>
         new(stmt, false, Current.TakeSnapshot(), new[] { d });

--- a/Vidyano.Script/Runtime/Mode.cs
+++ b/Vidyano.Script/Runtime/Mode.cs
@@ -11,8 +11,10 @@ namespace Vidyano.Script.Runtime;
 public enum GuardMode
 {
     /// <summary>
-    /// Default. Both intrinsic validity (visibility/read-only/edit-mode/action availability/required)
-    /// AND navigation reachability (you must have a UI path to the PO/Query) are enforced.
+    /// Default. Both intrinsic validity (read-only/edit-mode/action availability/required) AND
+    /// UI-reachability are enforced. Reachability covers two things a plain frontend user can't do: open
+    /// a PO/Query you have no menu path to, and read or write a <em>hidden</em> attribute
+    /// (<see cref="Vidyano.ViewModel.AttributeVisibility.Never"/> — the default editor never surfaces it).
     /// </summary>
     Navigation,
 
@@ -20,14 +22,17 @@ public enum GuardMode
     /// Intrinsic validity enforced; reachability reported as a warning but not enforced.
     /// Use to test security: a restricted user trying a direct PO open should produce both a server
     /// 'access denied' AND a 'not-reachable' warning. A regression that grants direct access loses
-    /// the server error but keeps the warning.
+    /// the server error but keeps the warning. Setting a hidden attribute is likewise allowed here but
+    /// carries a <c>guard-attribute-hidden</c> warning (a hidden read is allowed silently — it's
+    /// observational).
     /// </summary>
     Audit,
 
     /// <summary>
-    /// Intrinsic validity enforced; reachability silently skipped. Escape hatch for setup scripts
-    /// that need to plant fixtures by ID. The script must declare this explicitly so reviewers see
-    /// what's being bypassed.
+    /// Intrinsic validity enforced; reachability silently skipped. Escape hatch for setup scripts that
+    /// need to plant fixtures by ID or drive a hidden attribute the way a custom web component would
+    /// (Core itself never blocks a hidden-but-editable write — only read-only). The script must declare
+    /// this explicitly so reviewers see what's being bypassed.
     /// </summary>
     Direct,
 }

--- a/Vidyano.Script/Runtime/OpResult.cs
+++ b/Vidyano.Script/Runtime/OpResult.cs
@@ -13,9 +13,14 @@ public readonly record struct OpResult<T>(bool Ok, T? Value, Diagnostic? Error)
     public static OpResult<T> Fail(Diagnostic error) => new(false, default, error);
 }
 
-/// <summary>Non-generic outcome (no payload).</summary>
-public readonly record struct OpResult(bool Ok, Diagnostic? Error)
+/// <summary>Non-generic outcome (no payload). A successful outcome may carry an optional
+/// <see cref="Warning"/> — a non-failing diagnostic that rides on the passing statement (same pattern as
+/// FOR-EACH truncation). Used by the mode-aware visibility guard to allow-but-warn in <c>audit</c> mode.</summary>
+public readonly record struct OpResult(bool Ok, Diagnostic? Error, Diagnostic? Warning = null)
 {
     public static OpResult Success { get; } = new(true, null);
     public static OpResult Fail(Diagnostic error) => new(false, error);
+
+    /// <summary>This outcome with a warning attached. Only meaningful on a successful result.</summary>
+    public OpResult WithWarning(Diagnostic warning) => this with { Warning = warning };
 }

--- a/Vidyano.Script/Runtime/VidyanoSession.cs
+++ b/Vidyano.Script/Runtime/VidyanoSession.cs
@@ -991,8 +991,9 @@ public sealed class VidyanoSession : IDisposable
 
     /// <summary>
     /// Sets an attribute. Distinguishes four cases and uses a different <see cref="ErrorKind"/> for each:
-    /// the attribute doesn't exist (typo → suggest), it exists but is hidden, it exists but is read-only,
-    /// and the PO isn't in edit mode (auto-enter, with a warning diagnostic so the script author sees it).
+    /// the attribute doesn't exist (typo → suggest), it exists but is hidden (mode-dependent — see
+    /// <see cref="SetAttributeOnAsync"/>), it exists but is read-only, and the PO isn't in edit mode
+    /// (auto-enter, with a warning diagnostic so the script author sees it).
     /// </summary>
     /// <remarks>
     /// For reference attributes (<see cref="PersistentObjectAttributeWithReference"/>) the runner does
@@ -1005,27 +1006,35 @@ public sealed class VidyanoSession : IDisposable
     ///   override the search text, or <see cref="ReferenceHint.RawId"/> to bypass the lookup entirely.</item>
     /// </list>
     /// </remarks>
-    public async Task<OpResult> SetAttributeAsync(string name, object? value, SourceLocation loc, ReferenceHint? hint = null)
+    public async Task<OpResult> SetAttributeAsync(string name, object? value, SourceLocation loc, GuardMode mode, ReferenceHint? hint = null)
     {
         if (CurrentPo is null) return NoCurrentPo(loc);
-        return await SetAttributeOnAsync(CurrentPo, name, value, loc, hint).ConfigureAwait(false);
+        return await SetAttributeOnAsync(CurrentPo, name, value, loc, mode, hint).ConfigureAwait(false);
     }
 
     /// <summary>Attaches a file to a <c>BinaryFile</c>/<c>Image</c> attribute on the current PO (the
     /// <c>SET attr = FILE "..."</c> verb). The wire value depends on the attribute's data type — handled in
     /// <see cref="SetAttributeOnAsync"/> — so callers pass the raw file name and bytes, not a pre-formatted
     /// service string.</summary>
-    public async Task<OpResult> SetFileAttributeAsync(string name, string fileName, byte[] data, SourceLocation loc)
+    public async Task<OpResult> SetFileAttributeAsync(string name, string fileName, byte[] data, SourceLocation loc, GuardMode mode)
     {
         if (CurrentPo is null) return NoCurrentPo(loc);
-        return await SetAttributeOnAsync(CurrentPo, name, value: null, loc, hint: null, file: (fileName, data)).ConfigureAwait(false);
+        return await SetAttributeOnAsync(CurrentPo, name, value: null, loc, mode, hint: null, file: (fileName, data)).ConfigureAwait(false);
     }
 
     /// <summary>Sets an attribute on an explicit PO. Shared body between the implicit current-PO
     /// path (<see cref="SetAttributeAsync"/>) and the scoped path (<see cref="SetScopedAttributeAsync"/>).
     /// The only difference between callers is which PO they target — the hidden/readonly guards,
     /// the auto-enter-edit behaviour, and the reference-resolution branch are identical.</summary>
-    private async Task<OpResult> SetAttributeOnAsync(PersistentObject po, string name, object? value, SourceLocation loc, ReferenceHint? hint, (string FileName, byte[] Data)? file = null)
+    /// <remarks>
+    /// The hidden guard tiers with reachability rather than with read-only: <see cref="AttributeVisibility.Never"/>
+    /// only hides the field from the <em>default</em> editor, so a custom web component can still set it — and
+    /// Core's <see cref="PersistentObjectAttribute.UpdateValue"/> gates on read-only alone, never visibility.
+    /// So <c>navigation</c> enforces the standard-UI path (fail), <c>audit</c> allows the set but warns (the
+    /// custom-component path is observable), and <c>direct</c> allows it silently. Read-only stays a hard guard
+    /// in every mode (it is genuinely not settable, even by a custom component).
+    /// </remarks>
+    private async Task<OpResult> SetAttributeOnAsync(PersistentObject po, string name, object? value, SourceLocation loc, GuardMode mode, ReferenceHint? hint, (string FileName, byte[] Data)? file = null)
     {
         var attr = po.GetAttribute(name);
         if (attr is null)
@@ -1038,13 +1047,29 @@ public sealed class VidyanoSession : IDisposable
                 Hint: Suggester.Hint(name, candidates)));
         }
 
+        Diagnostic? hiddenWarning = null;
         if (!attr.IsVisible)
-            return OpResult.Fail(new Diagnostic(
-                ErrorKind.GuardAttributeHidden,
-                $"Attribute '{name}' exists on {po.Type} but is hidden — the UI would not allow setting it.",
-                loc,
-                Hint: "Use mode=direct only if you intend to bypass the UI guard.",
-                Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false }));
+        {
+            switch (mode)
+            {
+                case GuardMode.Navigation:
+                    return OpResult.Fail(new Diagnostic(
+                        ErrorKind.GuardAttributeHidden,
+                        $"Attribute '{name}' exists on {po.Type} but is hidden — the standard UI would not allow setting it.",
+                        loc,
+                        Hint: "A custom web component can still set a hidden attribute; use @mode = direct (or audit) to allow it.",
+                        Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false }));
+                case GuardMode.Audit:
+                    hiddenWarning = new Diagnostic(
+                        ErrorKind.GuardAttributeHidden,
+                        $"Setting hidden attribute '{name}' on {po.Type} — the standard UI would not show it; only a custom web component would.",
+                        loc,
+                        Hint: "Allowed because @mode = audit; direct mode allows it silently, navigation mode rejects it.",
+                        Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false });
+                    break;
+                // GuardMode.Direct: allow silently — the documented escape hatch for the custom-component path.
+            }
+        }
 
         if (attr.IsReadOnly)
             return OpResult.Fail(new Diagnostic(
@@ -1057,6 +1082,7 @@ public sealed class VidyanoSession : IDisposable
         if (!po.IsInEdit)
             po.Edit();
 
+        OpResult result;
         // SET attr = FILE "..." — format the bytes for the attribute's data type and assign. A file is
         // only meaningful for BinaryFile/Image; any other type fails loudly rather than writing garbage.
         if (file is { } f)
@@ -1064,26 +1090,31 @@ public sealed class VidyanoSession : IDisposable
             var formatted = FormatFileValue(attr.Type, attr.Name, f.FileName, f.Data, loc);
             if (!formatted.Ok) return OpResult.Fail(formatted.Error!);
             await attr.SetValueAsync(formatted.Value).ConfigureAwait(false);
-            return OpResult.Success;
+            result = OpResult.Success;
         }
-
-        if (attr is PersistentObjectAttributeWithReference refAttr)
-            return await SetReferenceAttributeAsync(refAttr, value, loc, hint).ConfigureAwait(false);
-
+        else if (attr is PersistentObjectAttributeWithReference refAttr)
+        {
+            result = await SetReferenceAttributeAsync(refAttr, value, loc, hint).ConfigureAwait(false);
+        }
         // Non-reference Options-bearing attrs (KeyValueList / Dropdown / ComboBox) accept the same
         // LOOKUP/ID hints — resolve the value against Options[] and assign the matching Key. A bare
         // `SET X = "y"` (hint == null) keeps the literal-write behaviour for back-compat.
-        if (hint is not null && attr.Options is { Length: > 0 } options)
+        else if (hint is not null && attr.Options is { Length: > 0 } options)
         {
             var text = value as string ?? value?.ToString() ?? "";
             var resolved = ResolveOption(options, text, hint.Kind, loc, attr.Name);
             if (!resolved.Ok) return OpResult.Fail(resolved.Error!);
             await attr.SetValueAsync(resolved.Value).ConfigureAwait(false);
-            return OpResult.Success;
+            result = OpResult.Success;
+        }
+        else
+        {
+            await attr.SetValueAsync(value).ConfigureAwait(false);
+            result = OpResult.Success;
         }
 
-        await attr.SetValueAsync(value).ConfigureAwait(false);
-        return OpResult.Success;
+        // Carry the audit-mode hidden warning on the (successful) set, so it surfaces without failing the run.
+        return hiddenWarning is not null && result.Ok ? result.WithWarning(hiddenWarning) : result;
     }
 
     /// <summary>Resolves a user-supplied option text against an <c>Options[]</c> array, returning
@@ -1363,20 +1394,20 @@ public sealed class VidyanoSession : IDisposable
     /// <summary>Sets an attribute on a scoped PO. Same edit/guard/reference-resolution semantics
     /// as <see cref="SetAttributeAsync"/>, but targeting <see cref="Vidyano.Client.Session"/> (or, in
     /// the future, <c>@user</c>/<c>@application</c>) instead of the navigation-stack top.</summary>
-    public async Task<OpResult> SetScopedAttributeAsync(string scope, string attributeName, object? value, ReferenceHint? hint, SourceLocation loc)
+    public async Task<OpResult> SetScopedAttributeAsync(string scope, string attributeName, object? value, ReferenceHint? hint, SourceLocation loc, GuardMode mode)
     {
         var poRes = ResolveScopePo(scope, loc);
         if (!poRes.Ok) return OpResult.Fail(poRes.Error!);
-        return await SetAttributeOnAsync(poRes.Value!, attributeName, value, loc, hint).ConfigureAwait(false);
+        return await SetAttributeOnAsync(poRes.Value!, attributeName, value, loc, mode, hint).ConfigureAwait(false);
     }
 
     /// <summary>Scoped counterpart of <see cref="SetFileAttributeAsync"/> — attaches a file to a
     /// <c>BinaryFile</c>/<c>Image</c> attribute on a scoped PO (<c>SET @scope.attr = FILE "..."</c>).</summary>
-    public async Task<OpResult> SetScopedFileAttributeAsync(string scope, string attributeName, string fileName, byte[] data, SourceLocation loc)
+    public async Task<OpResult> SetScopedFileAttributeAsync(string scope, string attributeName, string fileName, byte[] data, SourceLocation loc, GuardMode mode)
     {
         var poRes = ResolveScopePo(scope, loc);
         if (!poRes.Ok) return OpResult.Fail(poRes.Error!);
-        return await SetAttributeOnAsync(poRes.Value!, attributeName, value: null, loc, hint: null, file: (fileName, data)).ConfigureAwait(false);
+        return await SetAttributeOnAsync(poRes.Value!, attributeName, value: null, loc, mode, hint: null, file: (fileName, data)).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Vidyano.Script/Runtime/VidyanoSession.cs
+++ b/Vidyano.Script/Runtime/VidyanoSession.cs
@@ -1006,7 +1006,7 @@ public sealed class VidyanoSession : IDisposable
     ///   override the search text, or <see cref="ReferenceHint.RawId"/> to bypass the lookup entirely.</item>
     /// </list>
     /// </remarks>
-    public async Task<OpResult> SetAttributeAsync(string name, object? value, SourceLocation loc, GuardMode mode, ReferenceHint? hint = null)
+    public async Task<OpResult> SetAttributeAsync(string name, object? value, SourceLocation loc, GuardMode mode = GuardMode.Navigation, ReferenceHint? hint = null)
     {
         if (CurrentPo is null) return NoCurrentPo(loc);
         return await SetAttributeOnAsync(CurrentPo, name, value, loc, mode, hint).ConfigureAwait(false);
@@ -1016,7 +1016,7 @@ public sealed class VidyanoSession : IDisposable
     /// <c>SET attr = FILE "..."</c> verb). The wire value depends on the attribute's data type — handled in
     /// <see cref="SetAttributeOnAsync"/> — so callers pass the raw file name and bytes, not a pre-formatted
     /// service string.</summary>
-    public async Task<OpResult> SetFileAttributeAsync(string name, string fileName, byte[] data, SourceLocation loc, GuardMode mode)
+    public async Task<OpResult> SetFileAttributeAsync(string name, string fileName, byte[] data, SourceLocation loc, GuardMode mode = GuardMode.Navigation)
     {
         if (CurrentPo is null) return NoCurrentPo(loc);
         return await SetAttributeOnAsync(CurrentPo, name, value: null, loc, mode, hint: null, file: (fileName, data)).ConfigureAwait(false);
@@ -1052,13 +1052,9 @@ public sealed class VidyanoSession : IDisposable
         {
             switch (mode)
             {
-                case GuardMode.Navigation:
-                    return OpResult.Fail(new Diagnostic(
-                        ErrorKind.GuardAttributeHidden,
-                        $"Attribute '{name}' exists on {po.Type} but is hidden — the standard UI would not allow setting it.",
-                        loc,
-                        Hint: "A custom web component can still set a hidden attribute; use @mode = direct (or audit) to allow it.",
-                        Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false }));
+                case GuardMode.Direct:
+                    // Allow silently — the documented escape hatch for the custom-component path.
+                    break;
                 case GuardMode.Audit:
                     hiddenWarning = new Diagnostic(
                         ErrorKind.GuardAttributeHidden,
@@ -1067,7 +1063,16 @@ public sealed class VidyanoSession : IDisposable
                         Hint: "Allowed because @mode = audit; direct mode allows it silently, navigation mode rejects it.",
                         Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false });
                     break;
-                // GuardMode.Direct: allow silently — the documented escape hatch for the custom-component path.
+                case GuardMode.Navigation:
+                default:
+                    // Reject. The default arm fails safe: a future mode that hasn't opted into the hidden
+                    // escape hatch gets the strict behaviour rather than silently allowing a hidden write.
+                    return OpResult.Fail(new Diagnostic(
+                        ErrorKind.GuardAttributeHidden,
+                        $"Attribute '{name}' exists on {po.Type} but is hidden — the standard UI would not allow setting it.",
+                        loc,
+                        Hint: "A custom web component can still set a hidden attribute; use @mode = direct (or audit) to allow it.",
+                        Details: new Dictionary<string, object?> { ["attribute"] = name, ["isVisible"] = false }));
             }
         }
 
@@ -1394,7 +1399,7 @@ public sealed class VidyanoSession : IDisposable
     /// <summary>Sets an attribute on a scoped PO. Same edit/guard/reference-resolution semantics
     /// as <see cref="SetAttributeAsync"/>, but targeting <see cref="Vidyano.Client.Session"/> (or, in
     /// the future, <c>@user</c>/<c>@application</c>) instead of the navigation-stack top.</summary>
-    public async Task<OpResult> SetScopedAttributeAsync(string scope, string attributeName, object? value, ReferenceHint? hint, SourceLocation loc, GuardMode mode)
+    public async Task<OpResult> SetScopedAttributeAsync(string scope, string attributeName, object? value, ReferenceHint? hint, SourceLocation loc, GuardMode mode = GuardMode.Navigation)
     {
         var poRes = ResolveScopePo(scope, loc);
         if (!poRes.Ok) return OpResult.Fail(poRes.Error!);
@@ -1403,7 +1408,7 @@ public sealed class VidyanoSession : IDisposable
 
     /// <summary>Scoped counterpart of <see cref="SetFileAttributeAsync"/> — attaches a file to a
     /// <c>BinaryFile</c>/<c>Image</c> attribute on a scoped PO (<c>SET @scope.attr = FILE "..."</c>).</summary>
-    public async Task<OpResult> SetScopedFileAttributeAsync(string scope, string attributeName, string fileName, byte[] data, SourceLocation loc, GuardMode mode)
+    public async Task<OpResult> SetScopedFileAttributeAsync(string scope, string attributeName, string fileName, byte[] data, SourceLocation loc, GuardMode mode = GuardMode.Navigation)
     {
         var poRes = ResolveScopePo(scope, loc);
         if (!poRes.Ok) return OpResult.Fail(poRes.Error!);

--- a/docs/visc-language.md
+++ b/docs/visc-language.md
@@ -355,6 +355,17 @@ A `@mode` directive (or `VidyanoScriptOptions.Mode`) selects how strictly the en
 - **`audit`** — every observable side-effect is checked against the previous snapshot; useful for regression scripts.
 - **`direct`** — guards relaxed; lets scripts poke state directly. Reserved for setup/teardown.
 
+### Hidden attributes and the mode tier
+
+A **hidden** attribute (`AttributeVisibility.Never` — the default editor never renders it) is treated as a *reachability* concern, not a hard constraint: the standard UI can't touch it, but a custom web component can, and Core itself only ever blocks a **read-only** write (visibility never blocks a set). So `SET`/`EXPECT` on a hidden attribute tier with the mode:
+
+| | `navigation` | `audit` | `direct` |
+|---|---|---|---|
+| `SET <hidden>` | rejected (`guard-attribute-hidden`) | allowed **+ warning** | allowed silently |
+| `EXPECT <hidden>` (read) | rejected (`guard-attribute-hidden`) | allowed silently | allowed silently |
+
+Use `@mode = direct` (or `audit`) to script the custom-component path. **Read-only stays a hard guard in every mode** (`guard-attribute-read-only`) — a read-only attribute is genuinely not settable, even by a custom component, so no mode bypasses it.
+
 ---
 
 ## Verb quick reference


### PR DESCRIPTION
## Problem

Reports that users couldn't set hidden attributes (edited by a custom client-side web component). The production code was never at fault — Core's `PersistentObjectAttribute.UpdateValue` gates **only on read-only, never visibility**, so a custom component can set a hidden (`AttributeVisibility.Never`) attribute and the server accepts it on save.

The sole blocker was the `.visc` `SET` guard in `VidyanoSession.SetAttributeOnAsync`, which rejected hidden attributes **unconditionally in every mode** — its `"use mode=direct"` hint was never wired up (`_mode` wasn't passed in).

## Fix — visibility tiers with reachability

|  | `navigation` | `audit` | `direct` |
|---|---|---|---|
| `SET <hidden>` | reject (`guard-attribute-hidden`) | allow **+ warning** | allow silently |
| `EXPECT <hidden>` (read) | reject | allow silently | allow silently |

Read-only stays a hard guard in **all** modes (`guard-attribute-read-only`).

**Mechanics**
- `OpResult` gains an optional `Warning` (success-with-caveat), surfaced via `Interpreter.Wrap`/`Ok` — same "warning rides a passing statement" pattern as FOR-EACH truncation.
- `GuardMode` threaded through the four session `Set*` methods.
- `EXPECT` reads of hidden attributes tier the same way (reads/writes are symmetric custom-component concerns; needed to assert the round-trip). No audit warning on reads — observational.
- Scoped reads (`@session.attr`) and `FOLLOW` left strict intentionally.

## Tests

Added a hidden `Secret` attribute (`ProductActions.OnLoad` → `Visibility = Never`) and 3 in-process integration tests:
- `HiddenAttribute_NavigationMode_RejectsSet`
- `HiddenAttribute_DirectMode_AllowsAndRoundTrips` (SET → SAVE → reopen → `EXPECT Secret`)
- `HiddenAttribute_AuditMode_WarnsButAllows`

These also empirically confirm the in-process server sends hidden attributes to the client and accepts their values on SAVE.

## Verification
- Integration: **14/14** ✅ (3 new + 11 existing)
- Unit: **450/450** ✅
- Full solution builds clean (one pre-existing unrelated `VSTHRD200` warning)

## Docs
- `Mode.cs` enum docstring — visibility moved from intrinsic to reachability-tiered.
- `docs/visc-language.md` — new "Hidden attributes and the mode tier" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)