### PR TITLE
fix(core): read DateOnly/TimeOnly attributes instead of silently defaulting

### DIFF
--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -79,8 +79,9 @@ namespace Vidyano
 
         // The wire forms a Time attribute takes when backed by a TimeOnly property: the invariant short/long
         // time pattern. A TimeSpan-backed Time uses the "G" form instead (handled separately in
-        // FromServiceString). TimeSpan custom format: "hh"/"mm"/"ss" with escaped literal colons.
-        private static readonly string[] timeServiceFormats = { @"hh\:mm", @"hh\:mm\:ss" };
+        // FromServiceString). TimeSpan custom format: "h" accepts a single- or double-digit hour (so an
+        // unpadded "9:05" parses too), "mm"/"ss" with escaped literal colons.
+        private static readonly string[] timeServiceFormats = { @"h\:mm", @"h\:mm\:ss" };
 
         private static readonly Dictionary<string, NoInternetMessage> noInternetMessages = new Dictionary<string, NoInternetMessage>
         {
@@ -1012,7 +1013,11 @@ namespace Vidyano
                 // does — so it round-trips instead of failing the full-DateTime parse below and silently
                 // defaulting (a DateOnly-backed Date would otherwise read back as today / null).
                 if (typeName == DataTypes.Date || typeName == DataTypes.NullableDate)
-                    return DateTime.ParseExact(value.Split(' ')[0], "dd-MM-yyyy", CultureInfo.InvariantCulture);
+                {
+                    var spaceIndex = value.IndexOf(' ');
+                    var datePart = spaceIndex >= 0 ? value.Substring(0, spaceIndex) : value;
+                    return DateTime.ParseExact(datePart, "dd-MM-yyyy", CultureInfo.InvariantCulture);
+                }
 
                 if (type == typeof(DateTime) || type == typeof(DateTime?))
                     return DateTime.ParseExact(value, "dd-MM-yyyy HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture);

--- a/Vidyano.Core/Client.cs
+++ b/Vidyano.Core/Client.cs
@@ -77,6 +77,11 @@ namespace Vidyano
             ["NULLABLEGUID"] = typeof(Guid?),
         };
 
+        // The wire forms a Time attribute takes when backed by a TimeOnly property: the invariant short/long
+        // time pattern. A TimeSpan-backed Time uses the "G" form instead (handled separately in
+        // FromServiceString). TimeSpan custom format: "hh"/"mm"/"ss" with escaped literal colons.
+        private static readonly string[] timeServiceFormats = { @"hh\:mm", @"hh\:mm\:ss" };
+
         private static readonly Dictionary<string, NoInternetMessage> noInternetMessages = new Dictionary<string, NoInternetMessage>
         {
             { "en", new NoInternetMessage("Unable to connect to the server.", "Please check your internet connection settings and try again.", "Try again") },
@@ -1002,14 +1007,28 @@ namespace Vidyano
                     return Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
                 }
 
+                // A Date (server-side DateOnly) arrives as "dd-MM-yyyy" with no time, but the client models it
+                // as a midnight DateTime. Parse the date part only — tolerating a trailing time, as the server
+                // does — so it round-trips instead of failing the full-DateTime parse below and silently
+                // defaulting (a DateOnly-backed Date would otherwise read back as today / null).
+                if (typeName == DataTypes.Date || typeName == DataTypes.NullableDate)
+                    return DateTime.ParseExact(value.Split(' ')[0], "dd-MM-yyyy", CultureInfo.InvariantCulture);
+
                 if (type == typeof(DateTime) || type == typeof(DateTime?))
                     return DateTime.ParseExact(value, "dd-MM-yyyy HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture);
 
                 if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
                     return DateTimeOffset.ParseExact(value, "dd-MM-yyyy HH:mm:ss.FFFFFFF K", CultureInfo.InvariantCulture);
 
+                // A Time (server-side TimeOnly) arrives as the invariant "HH:mm" / "HH:mm:ss"; a TimeSpan-backed
+                // Time arrives as the "G" form. Accept all three, modelled client-side as a TimeSpan.
                 if (type == typeof(TimeSpan) || type == typeof(TimeSpan?))
+                {
+                    if (TimeSpan.TryParseExact(value, timeServiceFormats, CultureInfo.InvariantCulture, out var time))
+                        return time;
+
                     return TimeSpan.ParseExact(value, "G", CultureInfo.InvariantCulture);
+                }
 
                 return null;
             }

--- a/Vidyano.Script.IntegrationTests/ShopContext.cs
+++ b/Vidyano.Script.IntegrationTests/ShopContext.cs
@@ -51,9 +51,9 @@ public sealed class ShopContext : NullTargetContext
         products.Clear();
         products.AddRange(
         [
-            new Product { Id = "1", Name = "Widget", Color = "Blue", Category = "1", Title = _L("Widget", "Hulpmiddel", "Werkzeug") },
-            new Product { Id = "2", Name = "Gadget", Color = "Red", Category = "2", Title = _L("Gadget", "Apparaat", "Gerät") },
-            new Product { Id = "3", Name = "Gizmo", Color = "Green", Category = "1", Title = _L("Gizmo", "Ding", "Dingsda") },
+            new Product { Id = "1", Name = "Widget", Color = "Blue", Category = "1", Title = _L("Widget", "Hulpmiddel", "Werkzeug"), ReleaseDate = new DateOnly(2024, 3, 15), ReleaseTime = new TimeOnly(14, 30, 0) },
+            new Product { Id = "2", Name = "Gadget", Color = "Red", Category = "2", Title = _L("Gadget", "Apparaat", "Gerät"), ReleaseDate = new DateOnly(2023, 11, 1), ReleaseTime = new TimeOnly(9, 5, 0) },
+            new Product { Id = "3", Name = "Gizmo", Color = "Green", Category = "1", Title = _L("Gizmo", "Ding", "Dingsda"), ReleaseDate = new DateOnly(2025, 1, 20), ReleaseTime = new TimeOnly(23, 59, 0) },
         ]);
 
         documents.Clear();
@@ -111,6 +111,16 @@ public sealed class Product
     /// come from the <c>WithLanguage(...)</c> set in <see cref="InProcessVidyanoBackend"/>. Fully qualified
     /// to the SERVER type (see <see cref="ShopContext"/>'s <c>_L</c> note on the enclosing-namespace pitfall).</summary>
     public global::Vidyano.Service.TranslatedString? Title { get; set; }
+
+    /// <summary>A date-only field — surfaces as a <c>Date</c> attribute (the server maps <see cref="DateOnly"/>
+    /// → <c>DataTypes.Date</c>, wire value <c>"dd-MM-yyyy"</c> with no time). Exercises the client's Date
+    /// read path, which historically assumed a full <c>DateTime</c> string.</summary>
+    public DateOnly? ReleaseDate { get; set; }
+
+    /// <summary>A time-only field — surfaces as a <c>Time</c> attribute (the server maps <see cref="TimeOnly"/>
+    /// → <c>DataTypes.Time</c>). Exercises the client's Time read path, which historically assumed a
+    /// <c>TimeSpan</c> <c>"G"</c> string.</summary>
+    public TimeOnly? ReleaseTime { get; set; }
 
     // Nullable (like Category) so they're optional — a non-nullable string would be a required
     // attribute and the empty seed value would fail SAVE validation in the other Product tests.

--- a/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
+++ b/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
@@ -254,6 +254,40 @@ public sealed class VerbFamilyTests
     }
 
     [Fact]
+    public async Task DateOnly_TimeOnly_ReadRoundTrips()
+    {
+        // The server maps a DateOnly property to a Date attribute (wire "dd-MM-yyyy", no time) and a TimeOnly
+        // property to a Time attribute (wire "HH:mm"). The client modelled both as the full DateTime/TimeSpan
+        // forms and parsed only those, so a read silently defaulted (Date -> today/null, Time -> zero/null).
+        // This pins the corrected read path against real server output.
+        var conn = await _app.Backend.StartAsync();
+        var client = new Client(conn.HttpClient) { Uri = conn.BaseUri };
+        await client.SignInUsingCredentialsAsync("admin", "admin");
+
+        var po = await client.GetPersistentObjectAsync("Product", "1"); // Widget: 15-03-2024, 14:30
+        Assert.Equal(new DateTime(2024, 3, 15), (DateTime)po["ReleaseDate"].Value);
+        Assert.Equal(new TimeSpan(14, 30, 0), (TimeSpan)po["ReleaseTime"].Value);
+    }
+
+    [Fact]
+    public async Task DateOnly_SaveRoundTrips()
+    {
+        // The Date write path: the client sends its midnight DateTime as "dd-MM-yyyy HH:mm:ss.FFFFFFF" and the
+        // server's DateOnly parse takes the date part — so an edited date persists and reads back correctly.
+        var conn = await _app.Backend.StartAsync();
+        var client = new Client(conn.HttpClient) { Uri = conn.BaseUri };
+        await client.SignInUsingCredentialsAsync("admin", "admin");
+
+        var po = await client.GetPersistentObjectAsync("Product", "1");
+        po.Edit();
+        await po["ReleaseDate"].SetValueAsync(new DateTime(2030, 12, 25));
+        await po.Save();
+
+        var reloaded = await client.GetPersistentObjectAsync("Product", "1");
+        Assert.Equal(new DateTime(2030, 12, 25), (DateTime)reloaded["ReleaseDate"].Value);
+    }
+
+    [Fact]
     public async Task Confirm_AnswersRetryDialog()
     {
         AssertOk(await Run("""

--- a/Vidyano.Script.Tests/ServiceStringDateTimeTests.cs
+++ b/Vidyano.Script.Tests/ServiceStringDateTimeTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Vidyano;
+using Xunit;
+
+namespace Vidyano.Script.Tests;
+
+/// <summary>
+/// Coverage for <see cref="Client.FromServiceString"/> on Date and Time attributes. The server maps a
+/// <c>DateOnly</c> property to a <c>Date</c> attribute (wire <c>"dd-MM-yyyy"</c>, no time) and a
+/// <c>TimeOnly</c> property to a <c>Time</c> attribute (wire <c>"HH:mm"</c>/<c>"HH:mm:ss"</c>). The client
+/// models both as <c>DateTime</c>/<c>TimeSpan</c>; it must parse the server's short forms (and still the
+/// legacy full-<c>DateTime</c>/<c>"G"</c>-<c>TimeSpan</c> forms) instead of silently defaulting.
+/// </summary>
+public sealed class ServiceStringDateTimeTests
+{
+    [Theory]
+    [InlineData(DataTypes.Date)]
+    [InlineData(DataTypes.NullableDate)]
+    public void Date_ParsesDayMonthYear(string type)
+    {
+        Assert.Equal(new DateTime(2024, 3, 15), (DateTime)Client.FromServiceString("15-03-2024", type));
+    }
+
+    [Fact]
+    public void Date_ToleratesTrailingTime()
+    {
+        // A DateTime-backed Date (or any value the server stamps with a time) still resolves to the date.
+        Assert.Equal(new DateTime(2024, 3, 15), (DateTime)Client.FromServiceString("15-03-2024 00:00:00.0000000", DataTypes.Date));
+    }
+
+    [Theory]
+    [InlineData(DataTypes.Time)]
+    [InlineData(DataTypes.NullableTime)]
+    public void Time_ParsesHoursMinutes(string type)
+    {
+        Assert.Equal(new TimeSpan(14, 30, 0), (TimeSpan)Client.FromServiceString("14:30", type));
+    }
+
+    [Fact]
+    public void Time_ParsesHoursMinutesSeconds()
+    {
+        Assert.Equal(new TimeSpan(9, 5, 45), (TimeSpan)Client.FromServiceString("09:05:45", DataTypes.Time));
+    }
+
+    [Fact]
+    public void Time_StillParsesLegacyTimeSpanForm()
+    {
+        // A TimeSpan-backed Time serializes as the "G" form; the fallback must keep parsing it.
+        Assert.Equal(new TimeSpan(14, 30, 0), (TimeSpan)Client.FromServiceString("0:14:30:00.0000000", DataTypes.Time));
+    }
+
+    [Fact]
+    public void DateTime_FullFormUnaffected()
+    {
+        Assert.Equal(new DateTime(2024, 3, 15, 14, 30, 0), (DateTime)Client.FromServiceString("15-03-2024 14:30:00.0000000", DataTypes.DateTime));
+    }
+}

--- a/Vidyano.Script.Tests/ServiceStringDateTimeTests.cs
+++ b/Vidyano.Script.Tests/ServiceStringDateTimeTests.cs
@@ -42,6 +42,16 @@ public sealed class ServiceStringDateTimeTests
         Assert.Equal(new TimeSpan(9, 5, 45), (TimeSpan)Client.FromServiceString("09:05:45", DataTypes.Time));
     }
 
+    [Theory]
+    [InlineData("9:05")]
+    [InlineData("9:05:45")]
+    public void Time_ParsesSingleDigitHour(string wire)
+    {
+        // An unpadded single-digit hour must parse, not silently default to TimeSpan.Zero.
+        var expected = wire.Length > 4 ? new TimeSpan(9, 5, 45) : new TimeSpan(9, 5, 0);
+        Assert.Equal(expected, (TimeSpan)Client.FromServiceString(wire, DataTypes.Time));
+    }
+
     [Fact]
     public void Time_StillParsesLegacyTimeSpanForm()
     {


### PR DESCRIPTION
## Summary

Surfaced while auditing backend `DataType` special-cases after #42. The server moved date/time properties to `DateOnly`/`TimeOnly` (`VidyanoEx` maps `DateOnly` → `Date`, `TimeOnly` → `Time`), changing the wire form:

| DataType | server wire `Value` | client parsed only |
|---|---|---|
| `Date` / `NullableDate` (DateOnly) | `"15-03-2024"` (no time) | `"dd-MM-yyyy HH:mm:ss.FFFFFFF"` |
| `Time` / `NullableTime` (TimeOnly) | `"14:30"` | TimeSpan `"G"` |

The client models both as `DateTime`/`TimeSpan` and parsed **only** the full forms, so reading either threw and `FromServiceString` swallowed the exception into `GetDefaultValue` — **silent data corruption on every read**: a `Date` came back as **today** (or `null` when nullable), a `Time` as **zero**/`null`. No error surfaced.

## Fix

`Client.FromServiceString` now:
- parses `Date`/`NullableDate` from `"dd-MM-yyyy"` (tolerating a trailing time, exactly as the server's own parse does, so a `DateTime`-backed `Date` still works);
- parses `Time`/`NullableTime` from the invariant `"HH:mm"`/`"HH:mm:ss"`, falling back to the legacy `TimeSpan` `"G"` form so a `TimeSpan`-backed `Time` still works.

Centralized in `FromServiceString`, so attribute reads and query-cell reads alike are fixed.

## Scope: read-only (deliberate)

A `Time` attribute is **backend-ambiguous on the wire** — the server maps **both** `TimeSpan` (needs `"G"`) and `TimeOnly` (needs `"HH:mm:ss"`) to `DataTypes.Time`, and the client can't tell which from the type name. So the **write** format can't be chosen unilaterally without breaking one backend; it's left for a separate decision (verified: writing a `TimeOnly` today fails server-side with `Can't convert '0:08:15:00.0000000' to 'System.TimeOnly?'`). **`Date` write already works** (the server's `DateOnly` parse takes the date part of the client's `DateTime` string) — covered by a save round-trip test.

## Test plan
- [x] Unit (no server): `FromServiceString` on the short Date/Time forms, `HH:mm:ss`, the legacy `"G"` fallback, and the unaffected full `DateTime` — `ServiceStringDateTimeTests`.
- [x] Integration: `DateOnly`/`TimeOnly` read round-trip against the real in-process server (a `DateOnly`/`TimeOnly` field added to the shop model) — **verified to fail before the fix** (`Value` came back empty / today); plus a `Date` save round-trip.
- [x] 477 unit + 20 integration green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)