### PR TITLE
fix(visc): compare date/time attributes by value in EXPECT, not by culture-formatted string

### DIFF
--- a/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
+++ b/Vidyano.Script.IntegrationTests/VerbFamilyTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Vidyano.Script.Diagnostics;
 using Vidyano.Script.Runtime;
 using Xunit;
@@ -516,6 +517,44 @@ public sealed class VerbFamilyTests
 
         var reloaded = await client.GetPersistentObjectAsync("Product", "1");
         Assert.Equal(new DateTime(2030, 12, 25), (DateTime)reloaded["ReleaseDate"].Value);
+    }
+
+    [Fact]
+    public async Task Expect_TemporalAttributes_CompareByValue_IndependentOfCulture()
+    {
+        // attr.Value of a date/time attribute is a typed DateTime/TimeSpan; EXPECT must compare it BY VALUE
+        // against the literal's invariant service-string form (what SET writes), not via attr.Value.ToString()
+        // under the ambient thread culture. Pinning a non-matching locale (en-US: "3/15/2024 12:00:00 AM")
+        // proves the comparison no longer depends on the host machine's locale. Widget: 15-03-2024, 14:30.
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+            AssertOk(await Run("""
+                SIGN-IN admin / admin
+                OPEN MenuItem Home/Products
+                OPEN-ROW WHERE Name = "Widget"
+                EXPECT ReleaseDate = "15-03-2024"
+                EXPECT ReleaseDate != "20-01-2025"
+                EXPECT ReleaseDate < "01-01-2025"
+                EXPECT ReleaseDate > "01-01-2024"
+                EXPECT ReleaseTime = "14:30"
+                """));
+
+            // A non-matching date must make EXPECT fail — by-value comparison, not a silent default match.
+            var mismatch = await Run("""
+                SIGN-IN admin / admin
+                OPEN MenuItem Home/Products
+                OPEN-ROW WHERE Name = "Widget"
+                EXPECT ReleaseDate = "01-01-2000"
+                """);
+            Assert.False(mismatch.Ok, mismatch.Describe());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     [Fact]

--- a/Vidyano.Script/Diagnostics/VerbCatalog.cs
+++ b/Vidyano.Script/Diagnostics/VerbCatalog.cs
@@ -208,7 +208,8 @@ public static class VerbCatalog
             + "notifications, and round-tripped metadata. `= ID \"<id>\"` / `!= ID` compares a reference "
             + "attribute by its document id (ObjectId), symmetric with `SET <ref> = ID`. `LANGUAGE <lang>` "
             + "compares one translation of a TranslatedString attribute, symmetric with `SET … LANGUAGE`. "
-            + "`MATCHES` is a regex assertion (1s ReDoS guard). `Detail \"<name>\"` redirects query-family subjects, "
+            + "`MATCHES` is a regex assertion (1s ReDoS guard). Numeric and date/time subjects compare by value "
+            + "(locale-independent), the literal in the same invariant form `SET` uses. `Detail \"<name>\"` redirects query-family subjects, "
             + "and a named `Action <X> IS [NOT] AVAILABLE | VISIBLE` to that detail query's action (resolved on the detail alone).",
             ["EXPECT Status = \"Approved\"", "EXPECT Customer = ID \"people/acme\"", "EXPECT Title LANGUAGE nl = \"Hulpmiddel\"", "EXPECT TotalItems >= 1"],
             "assert", []),

--- a/Vidyano.Script/Runtime/Interpreter.cs
+++ b/Vidyano.Script/Runtime/Interpreter.cs
@@ -1737,6 +1737,17 @@ public sealed class Interpreter
         // ExpectOp.Matches is handled in DoExpect (it needs to distinguish a malformed pattern from a
         // non-match), so it never reaches Compare.
 
+        // Dates/times order by value (culture-irrelevant), like the numeric case below.
+        if (TryCompareTemporal(left, right, out var tsign))
+            return op switch
+            {
+                ExpectOp.Lt   => tsign < 0,
+                ExpectOp.LtEq => tsign <= 0,
+                ExpectOp.Gt   => tsign > 0,
+                ExpectOp.GtEq => tsign >= 0,
+                _ => false,
+            };
+
         // Numeric comparisons coerce both sides to decimal when possible.
         if (!TryCoerceDecimal(left, out var l) || !TryCoerceDecimal(right, out var r))
             return false;
@@ -1800,6 +1811,10 @@ public sealed class Interpreter
         if (a is bool ab && b is bool bb) return ab == bb;
         if (TryCoerceDecimal(a, out var ad) && TryCoerceDecimal(b, out var bd))
             return ad == bd;
+        // Dates/times compare by value (culture-irrelevant), like numbers above: coerce both sides via the
+        // invariant service-string form SET writes, so an EXPECT matches regardless of the host locale.
+        if (TryCompareTemporal(a, b, out var cmp))
+            return cmp == 0;
         var sa = a is string s1 ? s1 : a.ToString();
         var sb = b is string s2 ? s2 : b.ToString();
         return string.Equals(sa, sb, StringComparison.Ordinal);
@@ -1848,6 +1863,77 @@ public sealed class Interpreter
             case string s when decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsed): result = parsed; return true;
         }
         result = 0;
+        return false;
+    }
+
+    // Accepted invariant literal forms for temporal comparisons — the same service-string forms SET writes
+    // and the server reads back (Client.From/ToServiceString). A Date attribute reads back as a midnight
+    // DateTime, so the date-only "dd-MM-yyyy" form is accepted alongside the full DateTime form (the
+    // trailing ".FFFFFFF" is optional, so "dd-MM-yyyy HH:mm:ss" parses too).
+    private static readonly string[] dateTimeFormats = { "dd-MM-yyyy HH:mm:ss.FFFFFFF", "dd-MM-yyyy" };
+    private static readonly string[] dateTimeOffsetFormats = { "dd-MM-yyyy HH:mm:ss.FFFFFFF K" };
+    private static readonly string[] timeSpanFormats = { @"hh\:mm", @"hh\:mm\:ss", "c", "g", "G" };
+
+    private static bool TryCoerceDateTime(object? v, out DateTime result)
+    {
+        switch (v)
+        {
+            case DateTime dt: result = dt; return true;
+            case string s when DateTime.TryParseExact(s, dateTimeFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var p): result = p; return true;
+        }
+        result = default;
+        return false;
+    }
+
+    private static bool TryCoerceDateTimeOffset(object? v, out DateTimeOffset result)
+    {
+        switch (v)
+        {
+            case DateTimeOffset dto: result = dto; return true;
+            case string s when DateTimeOffset.TryParseExact(s, dateTimeOffsetFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var p): result = p; return true;
+        }
+        result = default;
+        return false;
+    }
+
+    private static bool TryCoerceTimeSpan(object? v, out TimeSpan result)
+    {
+        switch (v)
+        {
+            case TimeSpan ts: result = ts; return true;
+            case string s when TimeSpan.TryParseExact(s, timeSpanFormats, CultureInfo.InvariantCulture, out var p): result = p; return true;
+        }
+        result = default;
+        return false;
+    }
+
+    /// <summary>Compares two values by temporal value (culture-irrelevant) when at least one side is a typed
+    /// <see cref="DateTime"/>/<see cref="DateTimeOffset"/>/<see cref="TimeSpan"/> — the other side is parsed
+    /// from its invariant service-string form. The typed side comes from <c>attr.Value</c>; the literal side
+    /// is the script string. Returns <c>false</c> (caller falls back to a string compare) when the sides
+    /// aren't a coercible temporal pair, so an unparseable literal never silently matches a default value.
+    /// <paramref name="sign"/> carries the usual negative/zero/positive ordering.</summary>
+    private static bool TryCompareTemporal(object? a, object? b, out int sign)
+    {
+        sign = 0;
+        if (a is DateTimeOffset || b is DateTimeOffset)
+        {
+            if (!TryCoerceDateTimeOffset(a, out var x) || !TryCoerceDateTimeOffset(b, out var y)) return false;
+            sign = x.CompareTo(y);
+            return true;
+        }
+        if (a is DateTime || b is DateTime)
+        {
+            if (!TryCoerceDateTime(a, out var x) || !TryCoerceDateTime(b, out var y)) return false;
+            sign = x.CompareTo(y);
+            return true;
+        }
+        if (a is TimeSpan || b is TimeSpan)
+        {
+            if (!TryCoerceTimeSpan(a, out var x) || !TryCoerceTimeSpan(b, out var y)) return false;
+            sign = x.CompareTo(y);
+            return true;
+        }
         return false;
     }
 

--- a/docs/visc-language.md
+++ b/docs/visc-language.md
@@ -299,6 +299,14 @@ EXPECT Title = "Widget"                ## current-language value
 EXPECT Title LANGUAGE nl = "Hulpmiddel"
 ```
 
+**Dates, times & numbers compare by value** — for a numeric or date/time attribute, `=` / `!=` / `<` / `>` / `<=` / `>=` compare **by value**, not by formatted string, so an assertion matches regardless of the host machine's locale. Write the literal in the same invariant service-string form `SET` uses — `dd-MM-yyyy` (optionally `… HH:mm:ss.FFFFFFF`, with a trailing ` K` for an offset) for a date, `HH:mm[:ss]` for a time. A literal that can't be parsed as the attribute's type falls back to a plain string compare.
+
+```visc
+EXPECT ReleaseDate = "15-03-2024"      ## by value — locale-independent
+EXPECT ReleaseDate < "01-01-2025"
+EXPECT ReleaseTime = "14:30"
+```
+
 **Attributes & round-tripped metadata** — `EXPECT` reaches the server metadata (`Tag`, `Metadata`, `NavigationHints`, `TypeHints`) a browser would see:
 
 ```visc


### PR DESCRIPTION
## Problem

A `.visc` `EXPECT <dateAttribute> = "..."` (and `!=`, `<`, `>`) compared the attribute's value as a **culture-formatted string** rather than by value. `attr.Value` for a temporal attribute is a typed `DateTime`/`DateTimeOffset`/`TimeSpan`, but the comparison fell through to `value.ToString()` using the **ambient thread `CurrentCulture`** + an ordinal string compare (`Interpreter.cs` `ValuesEqual`). Numeric comparisons, by contrast, coerce both sides to `decimal` and compare **by value**, so they're culture-independent.

Result: a date/time `EXPECT` depended on the host machine's locale and couldn't match deterministically across machines/CI, while an equivalent numeric `EXPECT` worked everywhere. `<`/`>`/`<=`/`>=` on dates returned `false` outright (only `decimal` coercion was attempted).

## Fix

Add a temporal branch to `ValuesEqual` and `Compare`, mirroring the existing `TryCoerceDecimal` branch:

- When one side is a typed `DateTime`/`DateTimeOffset`/`TimeSpan` (from `attr.Value`), parse the literal side from the **same invariant service-string form `SET` writes** (`Client.From`/`ToServiceString`) and compare **by value**.
- Parsing is **explicit** in the interpreter, not via `Client.FromServiceString` — that swallows parse failures into a *default* value, which would silently match. An unparseable literal falls back to the existing ordinal string compare (no regression, no crash).
- The branch only fires when one side is already a typed temporal value, so two plain strings still compare as strings.
- Ordering (`<`/`>`/`<=`/`>=`) now works on dates/times too.

Accepted literal forms (what `SET` already uses): `dd-MM-yyyy` (optionally `… HH:mm:ss.FFFFFFF`, trailing ` K` for an offset), `HH:mm[:ss]` for times.

## Tests

`Vidyano.Script.IntegrationTests` — under a pinned `en-US` culture, a date/time `EXPECT` on `Product.ReleaseDate`/`ReleaseTime` matches by value (and ordering works), while a non-matching literal still fails. Verified **red on the pre-fix interpreter** (stash + rebuild) and green after. Full integration suite: 43/43 passing.

## Docs

Updated `docs/visc-language.md` (canonical) and the `EXPECT` entry in `vidyano help verbs` (`VerbCatalog.cs`).

## Scope

No change to the wire/`SET` date format or `Client.To/FromServiceString`. `MATCHES`/`CONTAINS` remain string operations. Out of scope: the separate `.NET`-vs-TS-client display-culture parity question (`Client.cs:580`).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Code session)